### PR TITLE
add tests for stoichiometric inconsistency [fix #1]

### DIFF
--- a/memote/suite/conftest.py
+++ b/memote/suite/conftest.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Configuration and fixtures for the test suite."""
+
 from __future__ import absolute_import
 
 import os
@@ -24,10 +26,6 @@ from os.path import basename, splitext
 import pytest
 from cobra.io import read_sbml_model
 
-"""
-Configuration and fixtures for the test suite.
-"""
-
 
 MODELS = os.environ["MEMOTE_MODEL"].split(os.pathsep)
 # MODELS = sorted(glob(join(dirname(__file__), "examples", "*.xml")))
@@ -36,6 +34,7 @@ MODELS = os.environ["MEMOTE_MODEL"].split(os.pathsep)
 @pytest.fixture(scope="session", params=MODELS,
                 ids=[splitext(basename(mod))[0] for mod in MODELS])
 def model(request):
+    """Fixture that provides the model for the complete test session."""
     # TODO: deal with and record warnings on load
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)

--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Run the test suite on an instance of `cobra.Model`.
-"""
+"""Run the test suite on an instance of `cobra.Model`."""
 
 from __future__ import absolute_import
 
@@ -44,6 +42,7 @@ class ConfigSectionSchema(object):
     @matches_section("memote")
     class Memote(SectionSchema):
         """Describes the memote configuration keys and values."""
+
         collect = Param(type=bool, default=True)
         addargs = Param(type=str, default="")
         model = Param(type=click.Path(exists=True, dir_okay=False),
@@ -51,11 +50,14 @@ class ConfigSectionSchema(object):
 
 
 class ConfigFileProcessor(ConfigFileReader):
+    """Determine which files to look for and what sections."""
+
     config_files = ["memote.ini", "setup.cfg"]
     config_section_schemas = [ConfigSectionSchema.Memote]
 
 
 def process_collect_flag(no_flag, context):
+    """Handle the report collection flag."""
     if no_flag is not None:
         return not no_flag
     elif "collect" in context.default_map:
@@ -65,6 +67,7 @@ def process_collect_flag(no_flag, context):
 
 
 def process_addargs(args, context):
+    """Handle additional args to pytest."""
     if args is not None:
         return shlex.split(args) + [dirname(__file__)]
     elif "addargs" in context.default_map:
@@ -75,6 +78,7 @@ def process_addargs(args, context):
 
 
 def process_model(model, context):
+    """Load model path(s) from different locations."""
     if len(model) > 0:
         os.environ["MEMOTE_MODEL"] = os.pathsep.join(model)
     elif "MEMOTE_MODEL" in os.environ:
@@ -103,6 +107,11 @@ def process_model(model, context):
 @click.argument("model", type=click.Path(exists=True, dir_okay=False), nargs=-1)
 @click.pass_context
 def cli(ctx, model, pytest_args, no_collect):
+    """
+    Memote command line tool.
+
+    Run `memote -h` for a better explanation.
+    """
     collect = process_collect_flag(no_collect, ctx)
     args = process_addargs(pytest_args, ctx)
     try:

--- a/memote/suite/test_basic.py
+++ b/memote/suite/test_basic.py
@@ -15,14 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Basic tests performed on an instance of `cobra.Model`."""
+
 from __future__ import absolute_import
 
 from memote.support.basic import check_metabolites_formula_presence
-
-
-"""
-Basic tests performed on an instance of `cobra.Model`.
-"""
 
 
 def test_model_id_presence(model, store):

--- a/memote/suite/test_consistency.py
+++ b/memote/suite/test_consistency.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Supporting functions for consistency checks performed on the model object.
-"""
+"""Supporting functions for stoichiometric consistency checks."""
 
 from __future__ import absolute_import
 

--- a/memote/suite/test_syntax.py
+++ b/memote/suite/test_syntax.py
@@ -15,15 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""Syntax tests performed on an instance of `cobra.Model`."""
+
 from __future__ import absolute_import
 
 from memote.support.syntax import (
     find_reaction_tag_transporter, find_rxn_id_compartment_suffix)
-
-
-"""
-Syntax tests performed on an instance of `cobra.Model`.
-"""
 
 
 def test_non_transp_rxn_id_compartment_suffix_match(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Supporting functions for basic checks performed on the model object.
-"""
+"""Supporting functions for basic checks performed on the model object."""
 
 from __future__ import absolute_import
 

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -267,6 +267,7 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-13):
     # deal with numerical instabilities
     left_ns[np.abs(left_ns) < tol] = 0.0
     inc_minimal = set()
+    LOGGER.debug("model has %d unconserved metabolites", len(unconserved_mets))
     for met in unconserved_mets:
         row = met_index[met]
         if (left_ns[row] == 0.0).all():
@@ -279,7 +280,7 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-13):
         while status == "optimal":
             LOGGER.debug("%s: status %s", met.id, status)
             solution = [model.metabolites.get_by_id(var.name[2:])
-                        for var in k_vars if var.primal > 0.1]
+                        for var in k_vars if var.primal > 0.0]
             LOGGER.debug("%s: set size %d", met.id, len(solution))
             inc_minimal.add(tuple(solution))
             add_cut(len(solution))

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -26,10 +26,12 @@ from operator import attrgetter
 
 import numpy as np
 import sympy
-from nump.linalg import svd
+from numpy.linalg import svd
 from six import iteritems
 
-__all__ = ("check_stoichiometric_consistency", "find_unconserved_metabolites")
+__all__ = (
+    "check_stoichiometric_consistency", "find_unconserved_metabolites",
+    "find_inconsistent_min_stoichiometry")
 
 LOGGER = logging.getLogger(__name__)
 
@@ -164,15 +166,15 @@ def find_unconserved_metabolites(model):
     LOGGER.debug("model has %d internal reactions", len(internal_rxns))
     # The binary variables k[i] in the paper.
     k_vars = list()
-    for metabolite in metabolites:
+    for met in metabolites:
         # The element m[i] of the mass vector.
-        m_var = Variable(metabolite.id)
-        k_var = Variable("k_{}".format(metabolite.id), type="binary")
+        m_var = Variable(met.id)
+        k_var = Variable("k_{}".format(met.id), type="binary")
         k_vars.append(k_var)
         stoich_trans.add([m_var, k_var])
         # This constraint is equivalent to 0 <= k[i] <= m[i].
         stoich_trans.add(Constraint(
-            k_var - m_var, ub=0, name="switch_{}".format(metabolite.id)))
+            k_var - m_var, ub=0, name="switch_{}".format(met.id)))
     stoich_trans.update()
     add_reaction_constraints(stoich_trans, internal_rxns, Constraint)
     # The objective is to maximize the binary indicators k[i], subject to the
@@ -193,18 +195,7 @@ def find_unconserved_metabolites(model):
             " (only optimal or infeasible expected).".format(status))
 
 
-def unconserved_minimal_set(metabolite_index, reaction_index, nullspace):
-    """
-    Find minimal unconserved sets.
-    """
-    # create continuous y vars
-    # create binary k vars
-    # constrain y - k to lower bound 0
-    # add nullspace constraints
-    # constrain y > 0 (y >= epsilon)
-    # minimize
-
-def find_inconsistent_min_stoichiometry(model, tol=1e-15):
+def find_inconsistent_min_stoichiometry(model, tol=1e-13):
     """
     Find minimal unbalanced reaction sets.
 
@@ -217,8 +208,51 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-15):
            "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
            Bioinformatics 24, no. 19 (2008): 2245.
     """
+    def create_milp_problem():
+        ns_problem = Model()
+        k_vars = list()
+        for met in metabolites:
+            # The element y[i] of the mass vector.
+            y_var = Variable(met.id)
+            k_var = Variable("k_{}".format(met.id), type="binary")
+            k_vars.append(k_var)
+            ns_problem.add([y_var, k_var])
+            # This constraint is equivalent to 0 <= y[i] <= k[i].
+            ns_problem.add(Constraint(
+                y_var - k_var, lb=0, name="switch_{}".format(met.id)))
+        ns_problem.update()
+        # add nullspace constraints
+        for (i, row) in enumerate(left_ns):
+            if (row == 0.0).all():
+                # singleton set!
+                continue
+            met = met_inv_map[i]
+            y_var = ns_problem.variables[met_inv_map[i].id]
+            expression = sympy.Add(*[coef * y_var for coef in row if coef != 0.0])
+            constraint = Constraint(expression, lb=0, ub=0,
+                                    name="ns_{}".format(met.id))
+            ns_problem.add(constraint)
+        # The objective is to minimize the binary indicators k[i], subject to the
+        # above inequality constraints.
+        ns_problem.objective = Objective(1)
+        ns_problem.objective.set_linear_coefficients(
+            {k_var: 1. for k_var in k_vars})
+        ns_problem.objective.direction = "min"
+        return ns_problem, k_vars
+
+    def add_cut(non_zero):
+        # non_zero corresponds to 'P' in the paper
+        expr = sympy.Add(*k_vars)
+        constr = Constraint(expr, ub=non_zero - 1)
+        problem.add(constr)
+
+
     if check_stoichiometric_consistency(model):
         return set()
+    Model = model.solver.interface.Model
+    Constraint = model.solver.interface.Constraint
+    Variable = model.solver.interface.Variable
+    Objective = model.solver.interface.Objective
     unconserved_mets = find_unconserved_metabolites(model)
     internal_rxns = set(model.reactions) - set(model.exchanges)
     internal_mets = set(met for rxn in internal_rxns for met in rxn.metabolites)
@@ -228,13 +262,27 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-15):
     reactions = sorted(internal_rxns, key=get_id)
     metabolites = sorted(internal_mets, key=get_id)
     stoich, met_index, rxn_index = stoichiometry_matrix(metabolites, reactions)
+    met_inv_map = {i: met for (met, i) in iteritems(met_index)}
     left_ns = nullspace(stoich.T)
+    # deal with numerical instabilities
+    left_ns[np.abs(left_ns) < tol] = 0.0
     inc_minimal = set()
     for met in unconserved_mets:
         row = met_index[met]
-        if (left_ns[row] < tol).all():
-            # singleton set
+        if (left_ns[row] == 0.0).all():
+            LOGGER.debug("%s: singleton minimal unconservable set", met.id)
+            # singleton set!
             inc_minimal.add((met,))
             continue
-
-    return set()
+        problem, k_vars = create_milp_problem()
+        status = problem.optimize()
+        while status == "optimal":
+            LOGGER.debug("%s: status %s", met.id, status)
+            solution = [model.metabolites.get_by_id(var.name[2:])
+                        for var in k_vars if var.primal > 0.1]
+            LOGGER.debug("%s: set size %d", met.id, len(solution))
+            inc_minimal.add(tuple(solution))
+            add_cut(len(solution))
+            status = problem.optimize()
+        LOGGER.debug("%s: last status %s", met.id, status)
+    return inc_minimal

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -228,12 +228,13 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-13):
                 continue
             met = met_inv_map[i]
             y_var = ns_problem.variables[met_inv_map[i].id]
-            expression = sympy.Add(*[coef * y_var for coef in row if coef != 0.0])
+            expression = sympy.Add(
+                *[coef * y_var for coef in row if coef != 0.0])
             constraint = Constraint(expression, lb=0, ub=0,
                                     name="ns_{}".format(met.id))
             ns_problem.add(constraint)
-        # The objective is to minimize the binary indicators k[i], subject to the
-        # above inequality constraints.
+        # The objective is to minimize the binary indicators k[i], subject to
+        # the above inequality constraints.
         ns_problem.objective = Objective(1)
         ns_problem.objective.set_linear_coefficients(
             {k_var: 1. for k_var in k_vars})
@@ -245,7 +246,6 @@ def find_inconsistent_min_stoichiometry(model, tol=1e-13):
         expr = sympy.Add(*k_vars)
         constr = Constraint(expr, ub=non_zero - 1)
         problem.add(constr)
-
 
     if check_stoichiometric_consistency(model):
         return set()

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -38,6 +38,15 @@ def check_stoichiometric_consistency(model):
     ----------
     model : cobra.Model
         The metabolic model under investigation.
+
+    Notes
+    -----
+    See [1]_ section 3.1 for a complete description of the algorithm.
+
+
+    .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
+           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           Bioinformatics 24, no. 19 (2008): 2245.
     """
     Model = model.solver.interface.Model
     Constraint = model.solver.interface.Constraint
@@ -78,6 +87,15 @@ def find_unconserved_metabolites(model):
     ----------
     model : cobra.Model
         The metabolic model under investigation.
+
+    Notes
+    -----
+    See [1]_ section 3.2 for a complete description of the algorithm.
+
+
+    .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
+           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           Bioinformatics 24, no. 19 (2008): 2245.
     """
     Model = model.solver.interface.Model
     Constraint = model.solver.interface.Constraint
@@ -104,12 +122,29 @@ def find_unconserved_metabolites(model):
     mass_balances_model.objective = Objective(1)
     mass_balances_model.objective.set_linear_coefficients(
         {var: 1. for var in y_vars})
+    mass_balances_model.objective.direction = 'max'
     status = mass_balances_model.optimize()
     if status == 'optimal':
-        return [model.metabolites.get_by_id(var.name.replace('y_', ''))
-                for var in y_vars if var.primal < 0.8]
+        return set([model.metabolites.get_by_id(var.name.replace('y_', ''))
+                    for var in y_vars if var.primal < 0.8])
     else:
-        raise Exception(
+        raise RuntimeError(
             "Couldn't compute list of unconserved metabolites."
             " Solver returned '{}' solution status"
-            " (only feasible or optimal expected).".format(status))
+            " (only optimal or infeasible expected).".format(status))
+
+
+def find_inconsistent_min_stoichiometry(model):
+    """
+    Find minimal unbalanced reaction sets.
+
+    Notes
+    -----
+    See [1]_ section 3.3 for a complete description of the algorithm.
+
+
+    .. [1] Gevorgyan, A., M. G Poolman, and D. A Fell.
+           "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
+           Bioinformatics 24, no. 19 (2008): 2245.
+    """
+    return set()

--- a/memote/support/consistency.py
+++ b/memote/support/consistency.py
@@ -16,18 +16,70 @@
 # limitations under the License.
 
 """
-Supporting functions for consistency checks performed on the model object.
+Supporting functions for stoichiometric consistency checks.
 """
 
 from __future__ import absolute_import
 
 import logging
+from operator import attrgetter
 
+import numpy as np
 import sympy
+from nump.linalg import svd
+from six import iteritems
 
 __all__ = ("check_stoichiometric_consistency", "find_unconserved_metabolites")
 
 LOGGER = logging.getLogger(__name__)
+
+
+def add_reaction_constraints(model, reactions, Constraint):
+    """
+    Add the stoichiometric coefficients as constraints.
+
+    Parameters
+    ----------
+    model : optlang.Model
+        The transposed stoichiometric matrix representation.
+    reactions : iterable
+        Container of `cobra.Reaction` instances.
+    Constraint : optlang.Constraint
+        The constraint class for the specific interface.
+    """
+    for rxn in reactions:
+        expression = sympy.Add(
+            *[coefficient * model.variables[metabolite.id]
+              for (metabolite, coefficient) in rxn.metabolites.items()])
+        constraint = Constraint(expression, lb=0, ub=0, name=rxn.id)
+        model.add(constraint)
+
+
+def stoichiometry_matrix(metabolites, reactions):
+    matrix = np.zeros((len(metabolites), len(reactions)))
+    met_index = {met: i for i, met in enumerate(metabolites)}
+    rxn_index = dict()
+
+    for i, rxn in enumerate(reactions):
+        rxn_index[rxn] = i
+        for met, coef in iteritems(rxn.metabolites):
+            j = met_index[met]
+            matrix[j, i] = coef
+
+    return matrix, met_index, rxn_index
+
+
+def nullspace(matrix, atol=1e-13, rtol=0.0):
+    """
+    Notes
+    -----
+    Adapted from:
+    https://scipy.github.io/old-wiki/pages/Cookbook/RankNullspace.html
+    """
+    matrix = np.atleast_2d(matrix)
+    u, s, vh = svd(matrix)
+    tol = max(atol, rtol * s[0])
+    return np.compress(s < tol, vh, axis=0).T
 
 
 def check_stoichiometric_consistency(model):
@@ -52,31 +104,33 @@ def check_stoichiometric_consistency(model):
     Constraint = model.solver.interface.Constraint
     Variable = model.solver.interface.Variable
     Objective = model.solver.interface.Objective
-    mass_balances_model = Model()
-    for metabolite in model.metabolites:
-        mass_balances_model.add(Variable(metabolite.id, lb=1))
-    for reaction in model.reactions:
-        if reaction in model.exchanges:
-            continue
-        expression = sympy.Add(
-            *[coefficient * mass_balances_model.variables[metabolite.id]
-              for (metabolite, coefficient) in reaction.metabolites.items()])
-        constraint = Constraint(expression, lb=0, ub=0, name=reaction.id)
-        mass_balances_model.add(constraint)
-    mass_balances_model.objective = Objective(1)
-    mass_balances_model.objective.set_linear_coefficients(
-        {var: 1. for var in mass_balances_model.variables})
-    mass_balances_model.objective.direction = 'min'
-    status = mass_balances_model.optimize()
-    if status == 'optimal':
+    # The transpose of the stoichiometric matrix N.T in the paper.
+    stoich_trans = Model()
+    # Exchange reactions are unbalanced by their nature.
+    # We exclude them here and only consider metabolites of the others.
+    internal_rxns = set(model.reactions) - set(model.exchanges)
+    metabolites = set(met for rxn in internal_rxns for met in rxn.metabolites)
+    LOGGER.debug("model has %d internal metabolites", len(metabolites))
+    LOGGER.debug("model has %d internal reactions", len(internal_rxns))
+    for metabolite in metabolites:
+        stoich_trans.add(Variable(metabolite.id, lb=1))
+    stoich_trans.update()
+    add_reaction_constraints(stoich_trans, internal_rxns, Constraint)
+    # The objective is to minimize the metabolite mass vector.
+    stoich_trans.objective = Objective(1)
+    stoich_trans.objective.set_linear_coefficients(
+        {var: 1. for var in stoich_trans.variables})
+    stoich_trans.objective.direction = "min"
+    status = stoich_trans.optimize()
+    if status == "optimal":
         return True
-    elif status == 'infeasible':
+    elif status == "infeasible":
         return False
     else:
-        raise Exception(
-            "Couldn't determine stoichiometric consistencty."
-            " Solver returned '{}' solution status"
-            " (only feasible or optimal expected).".format(status))
+        raise RuntimeError(
+            "Could not determine stoichiometric consistencty."
+            " Solver status is '{}'"
+            " (only optimal or infeasible expected).".format(status))
 
 
 def find_unconserved_metabolites(model):
@@ -101,40 +155,56 @@ def find_unconserved_metabolites(model):
     Constraint = model.solver.interface.Constraint
     Variable = model.solver.interface.Variable
     Objective = model.solver.interface.Objective
-    mass_balances_model = Model()
-    y_vars = list()
-    for metabolite in model.metabolites:
-        met_var = Variable(metabolite.id)
-        y_var = Variable('y_{}'.format(metabolite.id), type='binary')
-        y_vars.append(y_var)
-        mass_balances_model.add([met_var, y_var])
-        mass_balances_model.add(Constraint(
-            y_var - met_var, ub=0, name='switch_{}'.format(metabolite.id)))
-    mass_balances_model.update()
-    for reaction in model.reactions:
-        if reaction in model.exchanges:
-            continue
-        expression = sympy.Add(
-            *[coefficient * mass_balances_model.variables[metabolite.id]
-              for metabolite, coefficient in reaction.metabolites.items()])
-        constraint = Constraint(expression, lb=0, ub=0, name=reaction.id)
-        mass_balances_model.add(constraint)
-    mass_balances_model.objective = Objective(1)
-    mass_balances_model.objective.set_linear_coefficients(
-        {var: 1. for var in y_vars})
-    mass_balances_model.objective.direction = 'max'
-    status = mass_balances_model.optimize()
-    if status == 'optimal':
-        return set([model.metabolites.get_by_id(var.name.replace('y_', ''))
-                    for var in y_vars if var.primal < 0.8])
+    stoich_trans = Model()
+    # Exchange reactions are unbalanced by their nature.
+    # We exclude them here and only consider metabolites of the others.
+    internal_rxns = set(model.reactions) - set(model.exchanges)
+    metabolites = set(met for rxn in internal_rxns for met in rxn.metabolites)
+    LOGGER.debug("model has %d internal metabolites", len(metabolites))
+    LOGGER.debug("model has %d internal reactions", len(internal_rxns))
+    # The binary variables k[i] in the paper.
+    k_vars = list()
+    for metabolite in metabolites:
+        # The element m[i] of the mass vector.
+        m_var = Variable(metabolite.id)
+        k_var = Variable("k_{}".format(metabolite.id), type="binary")
+        k_vars.append(k_var)
+        stoich_trans.add([m_var, k_var])
+        # This constraint is equivalent to 0 <= k[i] <= m[i].
+        stoich_trans.add(Constraint(
+            k_var - m_var, ub=0, name="switch_{}".format(metabolite.id)))
+    stoich_trans.update()
+    add_reaction_constraints(stoich_trans, internal_rxns, Constraint)
+    # The objective is to maximize the binary indicators k[i], subject to the
+    # above inequality constraints.
+    stoich_trans.objective = Objective(1)
+    stoich_trans.objective.set_linear_coefficients(
+        {var: 1. for var in k_vars})
+    stoich_trans.objective.direction = "max"
+    status = stoich_trans.optimize()
+    if status == "optimal":
+        # TODO: See if that could be a Boolean test `bool(var.primal)`.
+        return set([model.metabolites.get_by_id(var.name[2:])
+                    for var in k_vars if var.primal < 0.8])
     else:
         raise RuntimeError(
-            "Couldn't compute list of unconserved metabolites."
-            " Solver returned '{}' solution status"
+            "Could not compute list of unconserved metabolites."
+            " Solver status is '{}'"
             " (only optimal or infeasible expected).".format(status))
 
 
-def find_inconsistent_min_stoichiometry(model):
+def unconserved_minimal_set(metabolite_index, reaction_index, nullspace):
+    """
+    Find minimal unconserved sets.
+    """
+    # create continuous y vars
+    # create binary k vars
+    # constrain y - k to lower bound 0
+    # add nullspace constraints
+    # constrain y > 0 (y >= epsilon)
+    # minimize
+
+def find_inconsistent_min_stoichiometry(model, tol=1e-15):
     """
     Find minimal unbalanced reaction sets.
 
@@ -147,4 +217,24 @@ def find_inconsistent_min_stoichiometry(model):
            "Detection of Stoichiometric Inconsistencies in Biomolecular Models."
            Bioinformatics 24, no. 19 (2008): 2245.
     """
+    if check_stoichiometric_consistency(model):
+        return set()
+    unconserved_mets = find_unconserved_metabolites(model)
+    internal_rxns = set(model.reactions) - set(model.exchanges)
+    internal_mets = set(met for rxn in internal_rxns for met in rxn.metabolites)
+    LOGGER.debug("model has %d internal metabolites", len(internal_mets))
+    LOGGER.debug("model has %d internal reactions", len(internal_rxns))
+    get_id = attrgetter("id")
+    reactions = sorted(internal_rxns, key=get_id)
+    metabolites = sorted(internal_mets, key=get_id)
+    stoich, met_index, rxn_index = stoichiometry_matrix(metabolites, reactions)
+    left_ns = nullspace(stoich.T)
+    inc_minimal = set()
+    for met in unconserved_mets:
+        row = met_index[met]
+        if (left_ns[row] < tol).all():
+            # singleton set
+            inc_minimal.add((met,))
+            continue
+
     return set()

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Helper functions that are used all over the memote package.
-"""
+"""Helper functions that are used all over the memote package."""
 
 from __future__ import absolute_import
 
@@ -28,7 +26,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 def find_demand_and_exchange_reactions(model):
-    """Return a list containing demand and exchange reactions of model
+    """
+    Return a list containing demand and exchange reactions of model.
 
     :param model: A cobrapy metabolic model
     :type model: cobra.core.Model.Model
@@ -76,8 +75,7 @@ def find_transport_reactions(model):
 
 def find_atp_adp_converting_reactions(model):
     """
-    Return a list of all reactions in which interact with both
-    atp and adp in all compartments.
+    Find reactions which interact with ATP and ADP.
 
     Parameters
     ----------

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -15,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Supporting functions for syntax checks performed on the model object.
-"""
+"""Supporting functions for syntax checks performed on the model object."""
 
 from __future__ import absolute_import
 
@@ -46,6 +44,8 @@ SUFFIX_MAP = dict({
 
 def find_rxn_id_compartment_suffix(model, suffix):
     """
+    Find incorrectly tagged IDs.
+
     Find non-transport reactions with metabolites in the given compartment
     whose ID is not tagged accordingly.
 
@@ -63,7 +63,6 @@ def find_rxn_id_compartment_suffix(model, suffix):
         compartment given by `suffix` but whose IDs do not have
         the `suffix` appended.
     """
-
     transport_rxns = find_transport_reactions(model)
     exchange_demand_rxns = find_demand_and_exchange_reactions(model)
 
@@ -83,8 +82,8 @@ def find_rxn_id_compartment_suffix(model, suffix):
 
 
 def find_reaction_tag_transporter(model):
-    """Return a list of transport reactions that have not been tagged as such.
-
+    """
+    Return incorrectly tagged transport reactions.
 
     A transport reaction is defined as follows:
        -- It contains metabolites from at least 2 compartments

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,22 +17,41 @@
 
 from __future__ import absolute_import
 
-import pytest
-from cobra import Model
+from os.path import join, dirname
 
+import pytest
+from optlang import available_solvers
+from cobra import Model
+from cobra.io import read_sbml_model
+
+import memote
 
 """
 Configuration and fixtures for the py.test suite.
 """
 
+# Gurobi MILP is currently not fully supported in optlang.
+# A MOSEK interface still needs to be completed.
+SUPPORTED_SOLVERS = [solver for solver in ["glpk", "cplex"] if
+                     available_solvers[solver.upper()]]
+
+
+@pytest.fixture(scope="session", params=SUPPORTED_SOLVERS)
+def solver(request):
+    return request.param
 
 @pytest.fixture(scope="function")
-def model(request):
+def model(request, solver):
     if request.param == "empty":
-        return Model(id_or_model=request.param, name=request.param)
+        model = Model(id_or_model=request.param, name=request.param)
+    elif request.param == "textbook":
+        model = read_sbml_model(join(dirname(memote.__file__), "suite", "examples",
+                               "EcoliCore.xml"))
     else:
         builder = getattr(request.module, "model_builder")
-        return builder(request.param)
+        model = builder(request.param)
+    model.solver = solver
+    return model
 
 
 @pytest.fixture(scope="session",

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -44,7 +44,7 @@ def model_builder(name):
         rxn_2 = cobra.Reaction("R2")
         rxn_2.add_metabolites({met_b: -1, met_b_prime: -1, met_c: 1})
         rxn_3 = cobra.Reaction("R3")
-        rxn_3.add_metabolites({met_c: -1, met_c_prime: -1, met_a: 1})
+        rxn_3.add_metabolites({met_c: -1, met_c_prime: -2, met_a: 1})
         model.add_reactions([rxn_1, rxn_2, rxn_3])
         return model
     if name == "eq-8":
@@ -63,7 +63,7 @@ def model_builder(name):
         model.add_reactions([rxn_1, rxn_2, rxn_3])
         return model
     if name == "fig-2":
-        # Example in figure 3 of Gevorgyan et al. (2008) Bioinformatics
+        # Example in figure 2 of Gevorgyan et al. (2008) Bioinformatics
         # Metabolites
         met_a = cobra.Metabolite("A")
         met_b = cobra.Metabolite("B")

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -105,10 +105,11 @@ def test_find_unconserved_metabolites(model, inconsistent):
 
 @pytest.mark.parametrize("model, inconsistent", [
     ("textbook", []),
-    ("fig-1", ["R1", "R2", "R3"]),
-    ("eq-8", ["R1", "R2", "R3"]),
-    ("fig-2", ["R2", "R4"]),
+    ("fig-1", [("A'",), ("B'",), ("C'",)]),
+    ("eq-8", [("A",), ("B",), ("C",)]),
+    ("fig-2", [("X",)]),
 ], indirect=["model"])
 def test_find_inconsistent_min_stoichiometry(model, inconsistent):
-    unconserved_rxns = consistency.find_inconsistent_min_stoichiometry(model)
-    assert set([rxn.id for rxn in unconserved_rxns]) == set(inconsistent)
+    unconserved_sets = consistency.find_inconsistent_min_stoichiometry(model)
+    for unconserved in unconserved_sets:
+        assert tuple(met.id for met in unconserved) in set(inconsistent)

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests ensuring that the functions in `memote.support.basic` work as expected.
+"""
+
+from __future__ import absolute_import
+
+import cobra
+import pytest
+
+import memote.support.consistency as consistency
+
+
+def model_builder(name):
+    model = cobra.Model(id_or_model=name, name=name)
+    if name == "fig-1":
+        # Example in figure 1 of Gevorgyan et al. (2008) Bioinformatics
+        # Metabolites
+        met_a = cobra.Metabolite("A")
+        met_a_prime = cobra.Metabolite("A'")
+        met_b = cobra.Metabolite("B")
+        met_b_prime = cobra.Metabolite("B'")
+        met_c = cobra.Metabolite("C")
+        met_c_prime = cobra.Metabolite("C'")
+        # Reactions
+        rxn_1 = cobra.Reaction("R1")
+        rxn_1.add_metabolites({met_a: -1, met_a_prime: -1, met_b: 1})
+        rxn_2 = cobra.Reaction("R2")
+        rxn_2.add_metabolites({met_b: -1, met_b_prime: -1, met_c: 1})
+        rxn_3 = cobra.Reaction("R3")
+        rxn_3.add_metabolites({met_c: -1, met_c_prime: -1, met_a: 1})
+        model.add_reactions([rxn_1, rxn_2, rxn_3])
+        return model
+    if name == "eq-8":
+        # Example in equation 8 of Gevorgyan et al. (2008) Bioinformatics
+        # Metabolites
+        met_a = cobra.Metabolite("A")
+        met_b = cobra.Metabolite("B")
+        met_c = cobra.Metabolite("C")
+        # Reactions
+        rxn_1 = cobra.Reaction("R1")
+        rxn_1.add_metabolites({met_a: -1, met_b: 1, met_c: 1})
+        rxn_2 = cobra.Reaction("R2")
+        rxn_2.add_metabolites({met_a: -1, met_b: 1})
+        rxn_3 = cobra.Reaction("R3")
+        rxn_3.add_metabolites({met_a: -1, met_c: 1})
+        model.add_reactions([rxn_1, rxn_2, rxn_3])
+        return model
+    if name == "fig-2":
+        # Example in figure 3 of Gevorgyan et al. (2008) Bioinformatics
+        # Metabolites
+        met_a = cobra.Metabolite("A")
+        met_b = cobra.Metabolite("B")
+        met_x = cobra.Metabolite("X")
+        met_p = cobra.Metabolite("P")
+        met_q = cobra.Metabolite("Q")
+        # Reactions
+        rxn_1 = cobra.Reaction("R1")
+        rxn_1.add_metabolites({met_a: -1, met_b: 1})
+        rxn_2 = cobra.Reaction("R2")
+        rxn_2.add_metabolites({met_a: -1, met_b: 1, met_x: 1})
+        rxn_3 = cobra.Reaction("R3")
+        rxn_3.add_metabolites({met_p: -1, met_q: 1})
+        rxn_4 = cobra.Reaction("R4")
+        rxn_4.add_metabolites({met_p: -1, met_q: 1, met_x: 1})
+        model.add_reactions([rxn_1, rxn_2, rxn_3, rxn_4])
+        return model
+
+
+@pytest.mark.parametrize("model, consistent", [
+    ("textbook", True),
+    ("fig-1", False),
+    ("eq-8", False),
+    ("fig-2", False),
+], indirect=["model"])
+def test_check_stoichiometric_consistency(model, consistent):
+    assert consistency.check_stoichiometric_consistency(model) is consistent
+
+
+@pytest.mark.parametrize("model, inconsistent", [
+    ("textbook", []),
+    ("fig-1", ["A'", "B'", "C'"]),
+    ("eq-8", ["A", "B", "C"]),
+    ("fig-2", ["X"]),
+], indirect=["model"])
+def test_find_unconserved_metabolites(model, inconsistent):
+    unconserved_mets = consistency.find_unconserved_metabolites(model)
+    assert set([met.id for met in unconserved_mets]) == set(inconsistent)
+
+@pytest.mark.parametrize("model, inconsistent", [
+    ("textbook", []),
+    ("fig-1", ["R1", "R2", "R3"]),
+    ("eq-8", ["R1", "R2", "R3"]),
+    ("fig-2", ["R2", "R4"]),
+], indirect=["model"])
+def test_find_inconsistent_min_stoichiometry(model, inconsistent):
+    unconserved_rxns = consistency.find_inconsistent_min_stoichiometry(model)
+    assert set([rxn.id for rxn in unconserved_rxns]) == set(inconsistent)

--- a/tox.ini
+++ b/tox.ini
@@ -21,10 +21,9 @@ commands =
 basepython=python
 deps=
     flake8
-    pydocstyle
+    flake8-docstrings
 commands=
     flake8 memote
-    pydocstyle memote
 
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:


### PR DESCRIPTION
* depend on cobrapy devel-2 again
* add different solvers to tests
* add skeleton for finding inconsistent minimal net stoichiometries

Although we add tests for the previous inconsistency functions, a third function is still missing and needs to be implemented. It does add tests for that case, too, which are failing until implemented correctly.