### PR TITLE
hide tracebacks adjust to cobra version

### DIFF
--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -113,6 +113,8 @@ def cli(ctx, model, pytest_args, no_collect):
         sys.exit(1)
     click.echo(os.environ["MEMOTE_MODEL"])
     if collect:
+        if "--tb" not in args:
+            args.extend(["--tb", "no"])
         errno = pytest.main(args, plugins=[MyPlugin()])
     else:
         errno = pytest.main(args)

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 python-libsbml
 swiglpk
-git+https://github.com/opencobra/cobrapy.git@devel-2#egg=cobra
+cobra>=0.6.0
 click
 click-configfile

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if set(['pytest', 'test', 'ptr']).intersection(sys.argv):
 requirements = [
     "python-libsbml",
     "swiglpk",
-    "cobra",
+    "cobra>=0.6.0",
     "click",
     "click-configfile",
     "future",


### PR DESCRIPTION
The long tracebacks were annoying when you really just want to collect data from the tests.