### PR TITLE
fix: change storage keys based on model path

### DIFF
--- a/memote/suite/reporting/bag.py
+++ b/memote/suite/reporting/bag.py
@@ -104,7 +104,7 @@ class ResultBagWrapper(object):
 
     def get_model_ids(self):
         """Get unique model IDs. Should normally be of length one."""
-        return self._bag.pluck("report").pluck("memote.suite.test_basic").\
+        return self._bag.pluck("report").pluck("test_basic").\
             pluck("model_id").distinct().compute()
 
     def get_basic_dataframe(self):
@@ -113,8 +113,7 @@ class ResultBagWrapper(object):
         data_types = ["int", "int", "int"]
         expected = pd.DataFrame({col: pd.Series(dtype=dt)
                                  for (col, dt) in zip(columns, data_types)})
-        df = self._bag.pluck("report", dict()).\
-            pluck("memote.suite.test_basic", dict()).\
+        df = self._bag.pluck("report", dict()).pluck("test_basic", dict()).\
             to_dataframe(expected).compute()
         df.index = self._index
         df["x"] = df.index

--- a/memote/suite/reporting/report.py
+++ b/memote/suite/reporting/report.py
@@ -48,7 +48,7 @@ class Report(object):
         """Render a one-shot report for a model."""
         template = self.env.get_template("basic.html")
         return template.render(
-            name=self.data["report"]["memote.suite.test_basic"]["model_id"],
+            name=self.data["report"]["test_basic"]["model_id"],
             timestamp=self.data["meta"]["timestamp"],
             data=self.data)
 

--- a/memote/suite/reporting/templates/basic.html
+++ b/memote/suite/reporting/templates/basic.html
@@ -9,9 +9,9 @@ super()
 
 {% block content -%}
 <div>
-{{ render_basic(data['report']['memote.suite.test_basic']) }}
+{{ render_basic(data['report']['test_basic']) }}
 </div>
 <div>
-{{ render_consistency(data['report']['memote.suite.test_consistency']) }}
+{{ render_consistency(data['report']['test_consistency']) }}
 </div>
 {%- endblock %}

--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -76,13 +76,14 @@ def process_collect_flag(no_flag, context):
 
 def process_addargs(args, context):
     """Handle additional args to pytest."""
+    tests_dir = join(dirname(__file__), "tests")
     if args is not None:
-        return shlex.split(args) + [dirname(__file__)]
+        return shlex.split(args) + [tests_dir]
     elif "addargs" in context.default_map:
         return shlex.split(context.default_map["addargs"]) +\
-            [dirname(__file__)]
+            [tests_dir]
     else:
-        return [dirname(__file__)]
+        return [tests_dir]
 
 
 def process_model(model, context):


### PR DESCRIPTION
The keys of the storage dict have changed and needed correction after reorganizing the package. The pytest invocation path was also adapted accordingly.