### PR TITLE
fix: add pytest files which are not part of a package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,7 @@ include HISTORY.rst
 include LICENSE
 include README.rst
 
-recursive-include memote *.html
+recursive-include memote *.py *.html
 recursive-include tests *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Since pytest does not use `__init__.py` files, the suite was not discovered and distributed.