### PR TITLE
feat: add test suite history command

### DIFF
--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -197,7 +197,7 @@ def collect(ctx):
     errno = pytest.main(ctx.obj["pytest_args"], plugins=[ResultCollectionPlugin(
         ctx.obj["model"], mode=collect, filename=ctx.obj["filename"],
         directory=ctx.obj["directory"], repo=ctx.obj["repo"])])
-    sys.exit(errno)
+    return errno
 
 
 @click.group(invoke_without_command=True,
@@ -243,7 +243,7 @@ def cli(ctx, no_collect, model, filename, directory, pytest_args):
     ctx.obj["pytest_args"] = process_addargs(pytest_args, ctx)
     ctx.obj["repo"] = probe_git()
     if ctx.invoked_subcommand is None:
-        collect(ctx)
+        sys.exit(collect(ctx))
 
 
 @cli.command()
@@ -324,4 +324,6 @@ def history(ctx, commits):
     3. By giving memote specific commit hashes, it will re-compute test results
        for those only.
     """
-    raise NotImplementedError(u"coming soon™")
+    if len(commits) > 0:
+        raise NotImplementedError(u"Coming soon™.")
+    directory = ctx.obj["directory"]

--- a/memote/suite/runner.py
+++ b/memote/suite/runner.py
@@ -340,7 +340,9 @@ def history(ctx, commits):
     branch = repo.active_branch
     ctx.obj["branch"] = branch
     ctx.obj["commit"] = branch.commit
-    LOGGER.info("Running suite for commit '%s'", branch.commit.hexsha)
+    LOGGER.info(
+        "%sRunning the test suite for commit '%s'.%s",
+        Fore.GREEN, branch.commit.hexsha, Fore.RESET)
     # Need to use a subprocess here such that the pytest plugin can be
     # successfully initialized with new arguments each time. Otherwise the
     # plugin remains immutable.
@@ -350,7 +352,9 @@ def history(ctx, commits):
     for commit in branch.commit.iter_parents():
         repo.git.checkout(commit)
         ctx.obj["commit"] = commit
-        LOGGER.info("Running the test suite for commit '%s'.", commit.hexsha)
+        LOGGER.info(
+            "%sRunning the test suite for commit '%s'.%s",
+            Fore.GREEN, commit.hexsha, Fore.RESET)
         proc = Process(target=collect, args=(ctx,))
         proc.start()
         proc.join()


### PR DESCRIPTION
We can now run the test suite for each commit that is parent to the current branch's HEAD.