### PR TITLE
63 check for gam

### DIFF
--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -107,3 +107,15 @@ def test_biomass_precursors_open_production(model, reaction, store):
     assert len(blocked) == 0, \
         "{}'s following precursors cannot be produced: {}" \
         "".format(reaction.id, ", ".join(blocked))
+
+
+@pytest.mark.parametrize("reaction", biomass_reactions, ids=biomass_ids)
+def test_gam_in_biomass(model, reaction, store):
+    """Expect the biomass reactions to contain atp and adp."""
+    store["gam_in_biomass"] = store.get(
+        "gam_in_biomass", list())
+    present = biomass.gam_in_biomass(reaction, model)
+    store["gam_in_biomass"].append(present)
+    assert present, \
+        "{} does not contain a term for growth-associated maintenance." \
+        "".format(reaction.id)

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -91,6 +91,7 @@ def find_blocked_biomass_precursors(reaction, model):
                 blocked_precursors.append(precursor)
     return blocked_precursors
 
+
 def gam_in_biomass(reaction, model):
     """
     Return boolean if biomass reaction includes growth-associated maintenance.

--- a/memote/support/biomass.py
+++ b/memote/support/biomass.py
@@ -23,6 +23,7 @@ import logging
 
 from six import iteritems
 from cobra.exceptions import Infeasible
+from memote.support.helpers import find_atp_adp_converting_reactions
 
 __all__ = (
     "sum_biomass_weight", "find_biomass_precursors",
@@ -89,3 +90,19 @@ def find_blocked_biomass_precursors(reaction, model):
             except Infeasible:
                 blocked_precursors.append(precursor)
     return blocked_precursors
+
+def gam_in_biomass(reaction, model):
+    """
+    Return boolean if biomass reaction includes growth-associated maintenance.
+
+    Parameters
+    ----------
+    reaction : cobra.core.reaction.Reaction
+        The biomass reaction of the model under investigation.
+
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    atp_adp_reactions = find_atp_adp_converting_reactions(model)
+    return reaction in set(atp_adp_reactions)


### PR DESCRIPTION
resolves #63 

So far this checks only if the Biomass reaction contains the metabolites atp_c and adp_c. I realised that looking for all the reactants of the hydrolysis reaction within the biomass metabolites might not be correct, as there are some (rare!) cases where one of them is balanced out by the same reactants contribution to the biomass. For instance, if the GAM requirement has been estimated as low (which is often the case when using the values from Neidhardt et. al.) it could happen that i.e. h2o_c that should be consumed in the hydrolysis reaction, is actually produced as a consequence of macromolecule biosynthesis.

Equally, checking for equal stoichiometry of all reactants in the hydrolysis reaction (x ATP + x H2O -> x ADP + x Pi + X H) is made more complicated when the biomass reaction requires the consumption of some of these reactants: ((x ATP + yATP_nucleotide) + x H2O -> x ADP + (x Pi - yPi_trace_nutrients) + X H)