### PR TITLE
33 annotation tests

### DIFF
--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -131,3 +131,28 @@ def test_rxn_wrong_annotation_ids(read_only_model, store):
             "{}".format(
                 db_id, ", ".join(store['rxn_wrong_annotation_ids'][db_id])
             )
+
+
+def test_met_id_namespace_consistency(read_only_model, store):
+    """
+    Expect metabolite IDs to be from the same namespace.
+    """
+    met_id_namespace = annotation.collect_met_id_namespace(read_only_model)
+    distribution = met_id_namespace[met_id_namespace == 1].count()
+    store['ids_in_each_namespace'] = \
+        {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
+         for item in distribution.index}
+    store['id_namespace_largest_fraction'] = distribution.idxmax()
+    # If largest fraction not bigg
+    # print warning that we prefer BiGG IDs to be used!
+    assert \
+        len(
+            store['ids_in_each_namespace']
+            [store['id_namespace_largest_fraction']]
+        ) == len(read_only_model.metabolites), \
+        "Metabolite IDs that don't belong to the largest fraction: {}".format(
+            [db_id + ":" + ", ".join(store['ids_in_each_namespace'][db_id])
+                for db_id in store['ids_in_each_namespace'].keys()
+                if store['ids_in_each_namespace'][db_id] != [] and
+                db_id != [store['id_namespace_largest_fraction']]]
+        )

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -20,171 +20,148 @@
 from __future__ import absolute_import
 
 from warnings import warn
+
+from pandas import DataFrame
+
 import memote.support.annotation as annotation
 from memote.support.helpers import get_difference
 
 
-def test_mets_without_annotation(read_only_model, store):
-    """Expect all metabolites to have a non-zero annotation attribute."""
-    store["metabolites_without_annotations"] = [
-        met.id for met in annotation.find_met_without_annotations(
-            read_only_model)]
-    assert len(store["metabolites_without_annotations"]) == 0, \
+def test_metabolite_annotation_presence(read_only_model, store):
+    """Expect all metabolites to have a non-empty annotation attribute."""
+    store["metabolites_without_annotation"] = [
+        met.id for met in annotation.find_components_without_annotation(
+            read_only_model.metabolites)]
+    assert len(store["metabolites_without_annotation"]) == 0, \
         "The following metabolites lack any form of annotation: " \
-        "{}".format(", ".join(store["metabolites_without_annotations"]))
+        "{}".format(", ".join(store["metabolites_without_annotation"]))
 
 
-def test_rxns_without_annotation(read_only_model, store):
-    """Expect all reactions to have a non-zero annotation attribute."""
-    store["reactions_without_annotations"] = [
+def test_reaction_annotation_presence(read_only_model, store):
+    """Expect all reactions to have a non-empty annotation attribute."""
+    store["reactions_without_annotation"] = [
         rxn.id for rxn in annotation.find_rxn_without_annotations(
-            read_only_model)]
-    assert len(store["reactions_without_annotations"]) == 0, \
+            read_only_model.reactions)]
+    assert len(store["reactions_without_annotation"]) == 0, \
         "The following reactions lack any form of annotation: " \
-        "{}".format(", ".join(store["reactions_without_annotations"]))
+        "{}".format(", ".join(store["reactions_without_annotation"]))
 
 
-def test_mets_annotation_overview(read_only_model, store):
+def test_metabolite_annotation_overview(read_only_model, store):
     """
-    Expect all mets to have annotations from common databases.
+    Expect all metabolites to have annotations from common databases.
 
-    The required databases are outlined in annotation.py.
+    The required databases are outlined in `annotation.py`.
     """
-    store['met_annotation_overview'] = \
-        annotation.generate_met_annotation_overview(read_only_model)
-    for db_id in annotation.METABOLITE_ANNOTATIONS:
-        assert \
-            len(store['met_annotation_overview'][db_id]) == 0, \
+    overview = annotation.generate_component_annotation_overview(
+        read_only_model, "metabolites")
+    store['met_annotation_overview'] = overview.to_dict()
+    for db in annotation.METABOLITE_ANNOTATIONS:
+        sub = overview.loc[~overview[db], db]
+        assert len(sub) == 0, \
             "The following metabolites lack annotation for {}: " \
-            "{}".format(
-                db_id, ", ".join(store['met_annotation_overview'][db_id])
-            )
+            "{}".format(db, ", ".join(sub.index))
 
 
-def test_rxns_annotation_overview(read_only_model, store):
+def test_reaction_annotation_overview(read_only_model, store):
     """
-    Expect all rxns to have annotations from common databases.
+    Expect all reactions to have annotations from common databases.
 
-    The required databases are outlined in annotation.py.
+    The required databases are outlined in `annotation.py`.
     """
-    store['rxn_annotation_overview'] = \
-        annotation.generate_rxn_annotation_overview(read_only_model)
-    for db_id in annotation.REACTION_ANNOTATIONS:
-        assert \
-            len(store['rxn_annotation_overview'][db_id]) == 0, \
+    overview = annotation.generate_component_annotation_overview(
+        read_only_model, "reactions")
+    store['rxn_annotation_overview'] = overview.to_dict()
+    for db in annotation.REACTION_ANNOTATIONS:
+        sub = overview.loc[~overview[db], db]
+        assert len(sub) == 0, \
             "The following reactions lack annotation for {}: " \
-            "{}".format(
-                db_id, ", ".join(store['rxn_annotation_overview'][db_id])
-            )
+            "{}".format(db, ", ".join(sub.index))
 
 
-def test_met_wrong_annotation_ids(read_only_model, store):
+def test_metabolite_annotation_wrong_ids(read_only_model, store):
     """
     Expect all annotations of metabolites to be in the correct format.
 
-    The required formats i.e. regex patterns are outlined in annotation.py.
+    The required formats, i.e., regex patterns are outlined in `annotation.py`.
     """
-    met_annotation_overview = \
-        annotation.generate_met_annotation_overview(read_only_model)
-    store['met_wrong_annotation_ids'] = annotation.find_wrong_annotation_ids(
-        read_only_model,
-        met_annotation_overview,
-        "met"
-    )
-    for db_id in annotation.METABOLITE_ANNOTATIONS:
-        assert \
-            len(store['met_wrong_annotation_ids'][db_id]) == \
-            len(
-                get_difference(
-                    met_annotation_overview[db_id],
-                    read_only_model,
-                    "met"
-                )
-            ), "The following metabolites use wrong IDs for {}: " \
-            "{}".format(
-                db_id, ", ".join(store['met_wrong_annotation_ids'][db_id])
-            )
+    has_annotation = annotation.generate_component_annotation_overview(
+        read_only_model, "metabolites")
+    matches = annotation.generate_component_annotation_miriam_match(
+        read_only_model, "metabolites")
+    wrong = DataFrame(has_annotation.values & (~matches.values),
+                      index=has_annotation.index,
+                      columns=has_annotation.columns)
+    store['met_wrong_annotation_ids'] = wrong.to_dict()
+    for db in annotation.METABOLITE_ANNOTATIONS:
+        sub = wrong.loc[wrong[db], db]
+        assert len(sub) == 0, \
+            "The following metabolites use wrong IDs for {}: " \
+            "{}".format(db, ", ".join(sub.index))
 
 
-def test_rxn_wrong_annotation_ids(read_only_model, store):
+def test_reaction_annotation_wrong_ids(read_only_model, store):
     """
     Expect all annotations of reactions to be in the correct format.
 
-    The required formats i.e. regex patterns are outlined in annotation.py.
+    The required formats, i.e., regex patterns are outlined in `annotation.py`.
     """
-    rxn_annotation_overview = \
-        annotation.generate_rxn_annotation_overview(read_only_model)
-    store['rxn_wrong_annotation_ids'] = annotation.find_wrong_annotation_ids(
-        read_only_model,
-        rxn_annotation_overview,
-        "rxn"
-    )
-    for db_id in annotation.REACTION_ANNOTATIONS:
-        assert \
-            len(store['rxn_wrong_annotation_ids'][db_id]) == \
-            len(
-                get_difference(
-                    rxn_annotation_overview[db_id],
-                    read_only_model,
-                    "rxn"
-                )
-            ), "The following reactions use wrong IDs for {}: " \
-            "{}".format(
-                db_id, ", ".join(store['rxn_wrong_annotation_ids'][db_id])
-            )
+    has_annotation = annotation.generate_component_annotation_overview(
+        read_only_model, "reactions")
+    matches = annotation.generate_component_annotation_miriam_match(
+        read_only_model, "reactions")
+    wrong = DataFrame(has_annotation.values & (~matches.values),
+                      index=has_annotation.index,
+                      columns=has_annotation.columns)
+    store["rxn_wrong_annotation_ids"] = wrong.to_dict()
+    for db in annotation.REACTION_ANNOTATIONS:
+        sub = wrong.loc[wrong[db], db]
+        assert len(sub) == 0, \
+            "The following reactions use wrong IDs for {}: " \
+            "{}".format(db, ", ".join(sub.index))
 
 
-def test_met_id_namespace_consistency(read_only_model, store):
+def test_metabolite_id_namespace_consistency(read_only_model, store):
     """Expect metabolite IDs to be from the same namespace."""
-    met_id_namespace = annotation.collect_met_id_namespace(read_only_model)
-    distribution = met_id_namespace[met_id_namespace == 1].count()
-    store['met_ids_in_each_namespace'] = \
-        {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
-         for item in distribution.index}
-    store['met_id_namespace_largest_fraction'] = distribution.idxmax()
-    if store['met_id_namespace_largest_fraction'] != 'bigg.metabolite':
+    met_id_ns = annotation.generate_component_id_namespace_overview(
+        read_only_model, "metabolites")
+    distribution = met_id_ns.sum()
+    store['met_ids_in_each_namespace'] = dict(distribution.iteritems())
+    # The BioCyc regex is extremely general, we ignore it here.
+    cols = list(distribution.index)
+    cols.remove('biocyc')
+    largest = distribution[cols].idxmax()
+    if distribution[largest] == 0:
+        largest = 'biocyc'
+    if largest != 'bigg.metabolite':
         warn(
-            'Memote currently only supports syntax checks for BiGG database '
-            'IDs. Please consider mapping your IDs from {} to BiGG'.format(
-                store['met_id_namespace_largest_fraction']
-            )
+            'memote currently only supports syntax checks for BiGG identifiers.'
+            ' Please consider mapping your IDs from {} to BiGG'
+            ''.format(largest)
         )
-    assert \
-        len(
-            store['met_ids_in_each_namespace']
-            [store['met_id_namespace_largest_fraction']]
-        ) == len(read_only_model.metabolites), \
-        "Metabolite IDs that don't belong to the largest fraction: {}".format(
-            [db_id + ":" + ", ".join(store['ids_in_each_namespace'][db_id])
-                for db_id in store['met_ids_in_each_namespace'].keys()
-                if store['met_ids_in_each_namespace'][db_id] != [] and
-                db_id != [store['met_id_namespace_largest_fraction']]]
-        )
+    assert distribution[largest] == len(read_only_model.metabolites), \
+        "Metabolite IDs that don't belong to the largest fraction: {}"\
+        "".format(met_id_ns.loc[~met_id_ns[largest], largest].index)
 
 
-def test_rxn_id_namespace_consistency(read_only_model, store):
+def test_reaction_id_namespace_consistency(read_only_model, store):
     """Expect reaction IDs to be from the same namespace."""
-    rxn_id_namespace = annotation.collect_rxn_id_namespace(read_only_model)
-    distribution = rxn_id_namespace[rxn_id_namespace == 1].count()
-    store['rxn_ids_in_each_namespace'] = \
-        {item: list(rxn_id_namespace[rxn_id_namespace[item] == 1].index)
-         for item in distribution.index}
-    store['rxn_id_namespace_largest_fraction'] = distribution.idxmax()
-    if store['met_id_namespace_largest_fraction'] != 'bigg.reaction':
+    rxn_id_ns = annotation.generate_component_id_namespace_overview(
+        read_only_model, "reactions")
+    distribution = rxn_id_ns.sum()
+    store['rxn_ids_in_each_namespace'] = dict(distribution.iteritems())
+    # The BioCyc regex is extremely general, we ignore it here.
+    cols = list(distribution.index)
+    cols.remove('biocyc')
+    largest = distribution[cols].idxmax()
+    if distribution[largest] == 0:
+        largest = 'biocyc'
+    if largest != 'bigg.reaction':
         warn(
-            'Memote currently only supports syntax checks for BiGG database '
-            'IDs. Please consider mapping your IDs from {} to BiGG'.format(
-                store['met_id_namespace_largest_fraction']
-            )
+            'memote currently only supports syntax checks for BiGG identifiers.'
+            ' Please consider mapping your IDs from {} to BiGG'
+            ''.format(largest)
         )
-    assert \
-        len(
-            store['rxn_ids_in_each_namespace']
-            [store['rxn_id_namespace_largest_fraction']]
-        ) == len(read_only_model.reactions), \
-        "Reaction IDs that don't belong to the largest fraction: {}".format(
-            [db_id + ":" + ", ".join(store['rxn_ids_in_each_namespace'][db_id])
-                for db_id in store['rxn_ids_in_each_namespace'].keys()
-                if store['rxn_ids_in_each_namespace'][db_id] != [] and
-                db_id != [store['rxn_id_namespace_largest_fraction']]]
-        )
+    assert distribution[largest] == len(read_only_model.metabolites), \
+        "Reaction IDs that don't belong to the largest fraction: {}" \
+        "".format(rxn_id_ns.loc[~rxn_id_ns[largest], largest].index)

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -135,9 +135,7 @@ def test_rxn_wrong_annotation_ids(read_only_model, store):
 
 
 def test_met_id_namespace_consistency(read_only_model, store):
-    """
-    Expect metabolite IDs to be from the same namespace.
-    """
+    """Expect metabolite IDs to be from the same namespace."""
     met_id_namespace = annotation.collect_met_id_namespace(read_only_model)
     distribution = met_id_namespace[met_id_namespace == 1].count()
     store['met_ids_in_each_namespace'] = \
@@ -165,9 +163,7 @@ def test_met_id_namespace_consistency(read_only_model, store):
 
 
 def test_rxn_id_namespace_consistency(read_only_model, store):
-    """
-    Expect reaction IDs to be from the same namespace.
-    """
+    """Expect reaction IDs to be from the same namespace."""
     rxn_id_namespace = annotation.collect_rxn_id_namespace(read_only_model)
     distribution = rxn_id_namespace[rxn_id_namespace == 1].count()
     store['rxn_ids_in_each_namespace'] = \

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -139,20 +139,45 @@ def test_met_id_namespace_consistency(read_only_model, store):
     """
     met_id_namespace = annotation.collect_met_id_namespace(read_only_model)
     distribution = met_id_namespace[met_id_namespace == 1].count()
-    store['ids_in_each_namespace'] = \
+    store['met_ids_in_each_namespace'] = \
         {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
          for item in distribution.index}
-    store['id_namespace_largest_fraction'] = distribution.idxmax()
+    store['met_id_namespace_largest_fraction'] = distribution.idxmax()
     # If largest fraction not bigg
     # print warning that we prefer BiGG IDs to be used!
     assert \
         len(
-            store['ids_in_each_namespace']
-            [store['id_namespace_largest_fraction']]
+            store['met_ids_in_each_namespace']
+            [store['met_id_namespace_largest_fraction']]
         ) == len(read_only_model.metabolites), \
         "Metabolite IDs that don't belong to the largest fraction: {}".format(
             [db_id + ":" + ", ".join(store['ids_in_each_namespace'][db_id])
-                for db_id in store['ids_in_each_namespace'].keys()
-                if store['ids_in_each_namespace'][db_id] != [] and
-                db_id != [store['id_namespace_largest_fraction']]]
+                for db_id in store['met_ids_in_each_namespace'].keys()
+                if store['met_ids_in_each_namespace'][db_id] != [] and
+                db_id != [store['met_id_namespace_largest_fraction']]]
+        )
+
+
+def test_rxn_id_namespace_consistency(read_only_model, store):
+    """
+    Expect metabolite IDs to be from the same namespace.
+    """
+    rxn_id_namespace = annotation.collect_rxn_id_namespace(read_only_model)
+    distribution = rxn_id_namespace[rxn_id_namespace == 1].count()
+    store['rxn_ids_in_each_namespace'] = \
+        {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
+         for item in distribution.index}
+    store['rxn_id_namespace_largest_fraction'] = distribution.idxmax()
+    # If largest fraction not bigg
+    # print warning that we prefer BiGG IDs to be used!
+    assert \
+        len(
+            store['rxn_ids_in_each_namespace']
+            [store['rxn_id_namespace_largest_fraction']]
+        ) == len(read_only_model.metabolites), \
+        "Metabolite IDs that don't belong to the largest fraction: {}".format(
+            [db_id + ":" + ", ".join(store['rxn_ids_in_each_namespace'][db_id])
+                for db_id in store['rxn_ids_in_each_namespace'].keys()
+                if store['rxn_ids_in_each_namespace'][db_id] != [] and
+                db_id != [store['rxn_id_namespace_largest_fraction']]]
         )

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -19,6 +19,7 @@
 
 from __future__ import absolute_import
 
+from warnings import warn
 import memote.support.annotation as annotation
 from memote.support.helpers import get_difference
 
@@ -143,8 +144,13 @@ def test_met_id_namespace_consistency(read_only_model, store):
         {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
          for item in distribution.index}
     store['met_id_namespace_largest_fraction'] = distribution.idxmax()
-    # If largest fraction not bigg
-    # print warning that we prefer BiGG IDs to be used!
+    if store['met_id_namespace_largest_fraction'] != 'bigg.metabolite':
+        warn(
+            'Memote currently only supports syntax checks for BiGG database '
+            'IDs. Please consider mapping your IDs from {} to BiGG'.format(
+                store['met_id_namespace_largest_fraction']
+            )
+        )
     assert \
         len(
             store['met_ids_in_each_namespace']
@@ -160,22 +166,27 @@ def test_met_id_namespace_consistency(read_only_model, store):
 
 def test_rxn_id_namespace_consistency(read_only_model, store):
     """
-    Expect metabolite IDs to be from the same namespace.
+    Expect reaction IDs to be from the same namespace.
     """
     rxn_id_namespace = annotation.collect_rxn_id_namespace(read_only_model)
     distribution = rxn_id_namespace[rxn_id_namespace == 1].count()
     store['rxn_ids_in_each_namespace'] = \
-        {item: list(met_id_namespace[met_id_namespace[item] == 1].index)
+        {item: list(met_id_namespace[rxn_id_namespace[item] == 1].index)
          for item in distribution.index}
     store['rxn_id_namespace_largest_fraction'] = distribution.idxmax()
-    # If largest fraction not bigg
-    # print warning that we prefer BiGG IDs to be used!
+    if store['met_id_namespace_largest_fraction'] != 'bigg.reaction':
+        warn(
+            'Memote currently only supports syntax checks for BiGG database '
+            'IDs. Please consider mapping your IDs from {} to BiGG'.format(
+                store['met_id_namespace_largest_fraction']
+            )
+        )
     assert \
         len(
             store['rxn_ids_in_each_namespace']
             [store['rxn_id_namespace_largest_fraction']]
         ) == len(read_only_model.metabolites), \
-        "Metabolite IDs that don't belong to the largest fraction: {}".format(
+        "Reaction IDs that don't belong to the largest fraction: {}".format(
             [db_id + ":" + ", ".join(store['rxn_ids_in_each_namespace'][db_id])
                 for db_id in store['rxn_ids_in_each_namespace'].keys()
                 if store['rxn_ids_in_each_namespace'][db_id] != [] and

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Annotation tests performed on an instance of `cobra.Model`."""
+
+from __future__ import absolute_import
+
+import memote.support.annotation as annotation
+
+
+def test_mets_without_annotation(read_only_model, store):
+    """Expect all metabolites to have a non-zero annotation attribute."""
+    store["metabolites_without_annotations"] = [
+        met.id for met in annotation.find_met_without_annotations(
+            read_only_model)]
+    assert len(store["metabolites_without_annotations"]) == 0, \
+        "The following metabolites lack any form of annotation: " \
+        "{}".format(", ".join(store["metabolites_without_annotations"]))
+
+
+def test_rxns_without_annotation(read_only_model, store):
+    """Expect all reactions to have a non-zero annotation attribute."""
+    store["reactions_without_annotations"] = [
+        rxn.id for rxn in annotation.find_rxn_without_annotations(
+            read_only_model)]
+    assert len(store["reactions_without_annotations"]) == 0, \
+        "The following reactions lack any form of annotation: " \
+        "{}".format(", ".join(store["reactions_without_annotations"]))

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -171,7 +171,7 @@ def test_rxn_id_namespace_consistency(read_only_model, store):
     rxn_id_namespace = annotation.collect_rxn_id_namespace(read_only_model)
     distribution = rxn_id_namespace[rxn_id_namespace == 1].count()
     store['rxn_ids_in_each_namespace'] = \
-        {item: list(met_id_namespace[rxn_id_namespace[item] == 1].index)
+        {item: list(rxn_id_namespace[rxn_id_namespace[item] == 1].index)
          for item in distribution.index}
     store['rxn_id_namespace_largest_fraction'] = distribution.idxmax()
     if store['met_id_namespace_largest_fraction'] != 'bigg.reaction':

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -40,3 +40,39 @@ def test_rxns_without_annotation(read_only_model, store):
     assert len(store["reactions_without_annotations"]) == 0, \
         "The following reactions lack any form of annotation: " \
         "{}".format(", ".join(store["reactions_without_annotations"]))
+
+
+def test_mets_annotation_overview(read_only_model, store):
+    """
+    Expect all mets to have annotations from common databases.
+
+    The required databases are outlined in annotation.py.
+    """
+    store['met_annotation_overview'] = \
+        annotation.generate_met_annotation_overview(read_only_model)
+    for db_id in annotation.METABOLITE_ANNOTATIONS:
+        assert \
+            len(store['met_annotation_overview'][db_id]) == \
+            len(read_only_model.metabolites), \
+            "The following metabolites lack annotation for {}: " \
+            "{}".format(
+                db_id, ", ".join(store['met_annotation_overview'][db_id])
+            )
+
+
+def test_rxns_annotation_overview(read_only_model, store):
+    """
+    Expect all rxns to have annotations from common databases.
+
+    The required databases are outlined in annotation.py.
+    """
+    store['rxn_annotation_overview'] = \
+        annotation.generate_rxn_annotation_overview(read_only_model)
+    for db_id in annotation.REACTION_ANNOTATIONS:
+        assert \
+            len(store['rxn_annotation_overview'][db_id]) == \
+            len(read_only_model.metabolites), \
+            "The following reactions lack annotation for {}: " \
+            "{}".format(
+                db_id, ", ".join(store['rxn_annotation_overview'][db_id])
+            )

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -185,7 +185,7 @@ def test_rxn_id_namespace_consistency(read_only_model, store):
         len(
             store['rxn_ids_in_each_namespace']
             [store['rxn_id_namespace_largest_fraction']]
-        ) == len(read_only_model.metabolites), \
+        ) == len(read_only_model.reactions), \
         "Reaction IDs that don't belong to the largest fraction: {}".format(
             [db_id + ":" + ", ".join(store['rxn_ids_in_each_namespace'][db_id])
                 for db_id in store['rxn_ids_in_each_namespace'].keys()

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import memote.support.annotation as annotation
+from memote.support.helpers import get_difference
 
 
 def test_mets_without_annotation(read_only_model, store):
@@ -75,4 +76,60 @@ def test_rxns_annotation_overview(read_only_model, store):
             "The following reactions lack annotation for {}: " \
             "{}".format(
                 db_id, ", ".join(store['rxn_annotation_overview'][db_id])
+            )
+
+
+def test_met_wrong_annotation_ids(read_only_model, store):
+    """
+    Expect all annotations of metabolites to be in the correct format.
+
+    The required formats i.e. regex patterns are outlined in annotation.py.
+    """
+    met_annotation_overview = \
+        annotation.generate_met_annotation_overview(read_only_model)
+    store['met_wrong_annotation_ids'] = annotation.find_wrong_annotation_ids(
+        read_only_model,
+        met_annotation_overview,
+        "met"
+    )
+    for db_id in annotation.METABOLITE_ANNOTATIONS:
+        assert \
+            len(store['met_wrong_annotation_ids'][db_id]) == \
+            len(
+                get_difference(
+                    met_annotation_overview[db_id],
+                    read_only_model,
+                    "met"
+                )
+            ), "The following metabolites use wrong IDs for {}: " \
+            "{}".format(
+                db_id, ", ".join(store['met_wrong_annotation_ids'][db_id])
+            )
+
+
+def test_rxn_wrong_annotation_ids(read_only_model, store):
+    """
+    Expect all annotations of reactions to be in the correct format.
+
+    The required formats i.e. regex patterns are outlined in annotation.py.
+    """
+    rxn_annotation_overview = \
+        annotation.generate_rxn_annotation_overview(read_only_model)
+    store['rxn_wrong_annotation_ids'] = annotation.find_wrong_annotation_ids(
+        read_only_model,
+        rxn_annotation_overview,
+        "rxn"
+    )
+    for db_id in annotation.REACTION_ANNOTATIONS:
+        assert \
+            len(store['rxn_wrong_annotation_ids'][db_id]) == \
+            len(
+                get_difference(
+                    rxn_annotation_overview[db_id],
+                    read_only_model,
+                    "rxn"
+                )
+            ), "The following reactions use wrong IDs for {}: " \
+            "{}".format(
+                db_id, ", ".join(store['rxn_wrong_annotation_ids'][db_id])
             )

--- a/memote/suite/tests/test_annotation.py
+++ b/memote/suite/tests/test_annotation.py
@@ -53,8 +53,7 @@ def test_mets_annotation_overview(read_only_model, store):
         annotation.generate_met_annotation_overview(read_only_model)
     for db_id in annotation.METABOLITE_ANNOTATIONS:
         assert \
-            len(store['met_annotation_overview'][db_id]) == \
-            len(read_only_model.metabolites), \
+            len(store['met_annotation_overview'][db_id]) == 0, \
             "The following metabolites lack annotation for {}: " \
             "{}".format(
                 db_id, ", ".join(store['met_annotation_overview'][db_id])
@@ -71,8 +70,7 @@ def test_rxns_annotation_overview(read_only_model, store):
         annotation.generate_rxn_annotation_overview(read_only_model)
     for db_id in annotation.REACTION_ANNOTATIONS:
         assert \
-            len(store['rxn_annotation_overview'][db_id]) == \
-            len(read_only_model.metabolites), \
+            len(store['rxn_annotation_overview'][db_id]) == 0, \
             "The following reactions lack annotation for {}: " \
             "{}".format(
                 db_id, ", ".join(store['rxn_annotation_overview'][db_id])

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -126,3 +126,26 @@ def find_rxn_without_annotations(model):
 
     """
     return [rxn for rxn in model.reactions if rxn.annotation == {}]
+
+
+def generate_rxn_annotation_overview(model):
+    """
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    dict
+        Dictionary that contains the database namespaces as keys and a list of
+        reactions without annotation in each namespace as the values.
+
+    """
+    rxn_annotation_overview = {key: [] for key in REACTION_ANNOTATIONS}
+    for rxn in model.reactions:
+        for key in REACTION_ANNOTATIONS:
+            if key not in rxn.annotation:
+                rxn_annotation_overview[key].append(rxm.id)
+    return rxn_annotation_overview

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -21,12 +21,11 @@ from __future__ import absolute_import
 
 import logging
 import re
-from builtins import str
+from future.utils import native_str
 
 import pandas as pd
 
 from collections import OrderedDict
-from memote.support.helpers import get_difference
 
 LOGGER = logging.getLogger(__name__)
 
@@ -100,6 +99,7 @@ def find_components_without_annotation(model, components):
     -------
     list
         The components without any annotation.
+
     """
     return [elem for elem in getattr(model, components) if
             elem.annotation is None or len(elem.annotation) == 0]
@@ -122,6 +122,7 @@ def generate_component_annotation_overview(model, components):
         The index of the table is given by the component identifiers. Each
         column corresponds to one MIRIAM database and a Boolean entry
         determines whether the annotation matches.
+
     """
     databases = list({
         "metabolites": METABOLITE_ANNOTATIONS,
@@ -152,20 +153,22 @@ def generate_component_annotation_miriam_match(model, components):
         The index of the table is given by the component identifiers. Each
         column corresponds to one MIRIAM database and a Boolean entry
         determines whether the annotation matches.
+
     """
     def check_annotation(key, annotation):
         if key not in annotation:
             return False
         test = annotation[key]
         pattern = patterns[key]
-        if isinstance(test, str):
+        if isinstance(test, native_str):
+            print("string match!")
             return pattern.match(test) is not None
         return all(pattern.match(elem) is not None for elem in test)
 
     patterns = {
-         "metabolites": METABOLITE_ANNOTATIONS,
-         "reactions": REACTION_ANNOTATIONS
-     }[components]
+        "metabolites": METABOLITE_ANNOTATIONS,
+        "reactions": REACTION_ANNOTATIONS
+    }[components]
     databases = list(patterns)
     data = list()
     index = list()
@@ -193,6 +196,7 @@ def generate_component_id_namespace_overview(model, components):
         The index of the table is given by the component identifiers. Each
         column corresponds to one MIRIAM database and a Boolean entry
         determines whether the annotation matches.
+
     """
     patterns = {
         "metabolites": METABOLITE_ANNOTATIONS,

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -243,7 +243,7 @@ def collect_met_id_namespace(model):
     # AND the Biocyc pattern we have to assume that this is a false
     # positive.
     df = pd.DataFrame.from_dict(data)
-    mets_matching_2_ids = df[df['biocyc'] == True].sum(axis=1).index
+    mets_matching_2_ids = df[df['biocyc'] == 1].sum(axis=1).index
     df.set_value(mets_matching_2_ids, 'biocyc', False)
     # Add a new column for all IDs that couldn't be matched to any of the
     # specified namespaces.
@@ -288,8 +288,8 @@ def collect_rxn_id_namespace(model):
     # AND the Biocyc pattern we have to assume that this is a false
     # positive.
     df = pd.DataFrame.from_dict(data)
-    mets_matching_2_ids = df[df['biocyc'] == True].sum(axis=1).index
-    df.set_value(mets_matching_2_ids, 'biocyc', False)
+    rxns_matching_2_ids = df[df['biocyc'] == 1].sum(axis=1).index
+    df.set_value(rxns_matching_2_ids, 'biocyc', False)
     # Add a new column for all IDs that couldn't be matched to any of the
     # specified namespaces.
     df['unknown'] = False

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -155,7 +155,7 @@ def generate_rxn_annotation_overview(model):
     return rxn_annotation_overview
 
 
-def find_wrong_annotation_ids(model, overview_dict, type):
+def find_wrong_annotation_ids(model, overview_dict, rxn_or_met):
     """
     Check the correctness of the annotations of annotated model components.
 
@@ -168,7 +168,7 @@ def find_wrong_annotation_ids(model, overview_dict, type):
         Dictionary that contains the database namespaces as keys and a list of
         mets/rxns without annotation in each namespace as the values.
 
-    type : str
+    rxn_or_met : str
         Either 'rxn' or 'met'.
 
     Returns
@@ -178,17 +178,17 @@ def find_wrong_annotation_ids(model, overview_dict, type):
         mets/rxns that have wrong ids of each namespace as the values.
 
     """
-    if type == 'rxn':
+    if rxn_or_met == 'rxn':
         items_anno_wrong_ids = {db_id: [] for db_id in REACTION_ANNOTATIONS}
         pattern_storage = REACTION_ANNOTATIONS
-    if type == 'met':
+    if rxn_or_met == 'met':
         items_anno_wrong_ids = {db_id: [] for db_id in METABOLITE_ANNOTATIONS}
         pattern_storage = METABOLITE_ANNOTATIONS
     for db_id in overview_dict:
         items_with_annotation = get_difference(
             overview_dict[db_id],
             model,
-            type
+            rxn_or_met
         )
         for item in items_with_annotation:
             if type(item.annotation[db_id]) == str:

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -245,6 +245,16 @@ def collect_met_id_namespace(model):
     df = pd.DataFrame.from_dict(data)
     mets_matching_2_ids = df[df['biocyc'] == True].sum(axis=1).index
     df.set_value(mets_matching_2_ids, 'biocyc', False)
+    # Add a new column for all IDs that couldn't be matched to any of the
+    # specified namespaces.
+    df['unknown'] = False
+    # The value should only be True if the entire column is False i.e. the
+    # Metabolite ID has no hits with any of the other namespaces.
+    df.set_value(
+        df[df.apply(pd.Series.nunique, axis=1) == 1].index,
+        'unknown',
+        True
+    )
     return df
 
 
@@ -278,6 +288,16 @@ def collect_rxn_id_namespace(model):
     # AND the Biocyc pattern we have to assume that this is a false
     # positive.
     df = pd.DataFrame.from_dict(data)
-    rxns_matching_2_ids = df[df['biocyc'] == True].sum(axis=1).index
-    df.set_value(rxns_matching_2_ids, 'biocyc', False)
+    mets_matching_2_ids = df[df['biocyc'] == True].sum(axis=1).index
+    df.set_value(mets_matching_2_ids, 'biocyc', False)
+    # Add a new column for all IDs that couldn't be matched to any of the
+    # specified namespaces.
+    df['unknown'] = False
+    # The value should only be True if the entire column is False i.e. the
+    # Reaction ID has no hits with any of the other namespaces.
+    df.set_value(
+        df[df.apply(pd.Series.nunique, axis=1) == 1].index,
+        'unknown',
+        True
+    )
     return df

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -190,7 +190,7 @@ def find_wrong_annotation_ids(model, overview_dict, type):
             model,
             type
         )
-        for item in items_with_annotation[db_id]:
+        for item in items_with_annotation:
             if type(item.annotation[db_id]) == str:
                 if not re.match(
                     pattern_storage[db_id], item.annotation[db_id]

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -106,7 +106,7 @@ def generate_met_annotation_overview(model):
     for met in model.metabolites:
         for key in METABOLITE_ANNOTATIONS:
             if key not in met.annotation:
-                met_annotation_overview[key].append(met.id)
+                met_annotation_overview[key].append(met)
     return met_annotation_overview
 
 
@@ -147,5 +147,5 @@ def generate_rxn_annotation_overview(model):
     for rxn in model.reactions:
         for key in REACTION_ANNOTATIONS:
             if key not in rxn.annotation:
-                rxn_annotation_overview[key].append(rxn.id)
+                rxn_annotation_overview[key].append(rxn)
     return rxn_annotation_overview

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -86,3 +86,21 @@ def find_met_without_annotations(model):
 
     """
     return [met for met in model.metabolites if met.annotation == {}]
+
+
+def find_rxn_without_annotations(model):
+    """
+    Find reactions with empty annotation attributes.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    list
+        Reactions that have empty annotation attributes.
+
+    """
+    return [rxn for rxn in model.reactions if rxn.annotation == {}]

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -188,7 +188,19 @@ def find_wrong_annotation_ids(model, overview_dict, type):
             model,
             type
         )
-        items_anno_wrong_ids[db_id] = \
-            [item for item in items_with_annotation[db_id]
-             if not re.match(pattern_storage[db_id], item.id)]
+        for item in items_with_annotation[db_id]:
+            if type(item.annotation[db_id]) == str:
+                if not re.match(
+                    pattern_storage[db_id], item.annotation[db_id]
+                ):
+                    items_anno_wrong_ids[db_id].append(item)
+            if type(item.annotation[db_id]) == list:
+                for anno_id in item.annotation[db_id]:
+                    if not re.match(
+                        pattern_storage[db_id], anno_id
+                    ):
+                        items_anno_wrong_ids[db_id].append(item)
+                        break
+                    else:
+                        pass
     return items_anno_wrong_ids

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -25,7 +25,7 @@ import re
 LOGGER = logging.getLogger(__name__)
 
 # MIRIAM (http://www.ebi.ac.uk/miriam/) styled identifiers for
-# common databases that currently included are:
+# common databases that are currently included are:
 # DB    rxn,met,gen url
 # 'MetaNetX'  ['rxn','met'] 'http://www.metanetx.org'
 # 'Kegg'  ['rxn','met'] 'http://www.kegg.jp/'

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -147,5 +147,5 @@ def generate_rxn_annotation_overview(model):
     for rxn in model.reactions:
         for key in REACTION_ANNOTATIONS:
             if key not in rxn.annotation:
-                rxn_annotation_overview[key].append(rxm.id)
+                rxn_annotation_overview[key].append(rxn.id)
     return rxn_annotation_overview

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -57,9 +57,8 @@ REACTION_ANNOTATIONS = {'metanetx.reaction': re.compile(r"^MNXR\d+$"),
 METABOLITE_ANNOTATIONS = {'metanetx.chemical': re.compile(r"^MNXM\d+$"),
                           'kegg.compound': re.compile(r"^C\d+$"),
                           'seed.compound': re.compile(r"^cpd\d+$"),
-                          'inchikey': re.compile(
-                            r"^[A-Z]{14}\-[A-Z]{10}(\-[A-Z])?"
-                            ),
+                          'inchikey': re.compile(r"^[A-Z]{14}\-"
+                                                 r"[A-Z]{10}(\-[A-Z])?"),
                           'chebi': re.compile(r"^CHEBI:\d+$"),
                           'hmdb': re.compile(r"^HMDB\d{5}$"),
                           'biocyc': re.compile(r"^[A-Z-0-9]+(?<!CHEBI)"
@@ -86,6 +85,29 @@ def find_met_without_annotations(model):
 
     """
     return [met for met in model.metabolites if met.annotation == {}]
+
+
+def generate_met_annotation_overview(model):
+    """
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    dict
+        Dictionary that contains the database namespaces as keys and a list of
+        metabolites without annotation in each namespace as the values.
+
+    """
+    met_annotation_overview = {key: [] for key in METABOLITE_ANNOTATIONS}
+    for met in model.metabolites:
+        for key in METABOLITE_ANNOTATIONS:
+            if key not in met.annotation:
+                met_annotation_overview[key].append(met.id)
+    return met_annotation_overview
 
 
 def find_rxn_without_annotations(model):

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -44,24 +44,23 @@ LOGGER = logging.getLogger(__name__)
 # 'Reactome'    ['met'] 'http://www.reactome.org/'
 # 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
 
-REACTION_ANNOTATIONS = [
-                        ('rhea', re.compile(r"^\d{5}$")),
+REACTION_ANNOTATIONS = [('rhea', re.compile(r"^\d{5}$")),
                         ('kegg.reaction', re.compile(r"^R\d+$")),
                         ('metanetx.reaction', re.compile(r"^MNXR\d+$")),
                         ('bigg.reaction', re.compile(r"^[a-z_A-Z0-9]+$")),
                         ('ec-code', re.compile(
-                             r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
-                             r"\d+\.\d+\.\d+\.-|"
-                             r"\d+\.\d+\.\d+\.(n)?\d+$")
+                            r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
+                            r"\d+\.\d+\.\d+\.-|"
+                            r"\d+\.\d+\.\d+\.(n)?\d+$")
                          ),
                         ('brenda', re.compile(
-                             r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
-                             r"\d+\.\d+\.\d+\.-|"
-                             r"\d+\.\d+\.\d+\.(n)?\d+$")
+                            r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
+                            r"\d+\.\d+\.\d+\.-|"
+                            r"\d+\.\d+\.\d+\.(n)?\d+$")
                          ),
                         ('biocyc', re.compile(
-                             r"^[A-Z-0-9]+(?<!CHEBI)"
-                             r"(\:)?[A-Za-z0-9+_.%-]+$")
+                            r"^[A-Z-0-9]+(?<!CHEBI)"
+                            r"(\:)?[A-Za-z0-9+_.%-]+$")
                          )
                         ]
 REACTION_ANNOTATIONS = OrderedDict(REACTION_ANNOTATIONS)

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -91,6 +91,7 @@ def find_met_without_annotations(model):
 
 def generate_met_annotation_overview(model):
     """
+    List metabolites which lack annotation for a given database.
 
     Parameters
     ----------
@@ -132,6 +133,7 @@ def find_rxn_without_annotations(model):
 
 def generate_rxn_annotation_overview(model):
     """
+    List reactions which lack annotation for a given database.
 
     Parameters
     ----------

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 import logging
 import re
+import pandas as pd
 
 from memote.support.helpers import (get_difference)
 
@@ -206,3 +207,60 @@ def find_wrong_annotation_ids(model, overview_dict, rxn_or_met):
                     else:
                         pass
     return items_anno_wrong_ids
+
+
+def collect_met_id_namespace(model):
+    """
+    Identify to which common database metabolite IDs belong.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    dataframe : pandas.core.frame.DataFrame
+        Table with metabolite IDs as rows and database namespaces as the
+        columns. Cell values are boolean.
+
+    """
+    data = {}
+    for db_id in METABOLITE_ANNOTATIONS:
+        data[db_id] = {}
+        for met in model.metabolites:
+            no_compartment_id = met.id.rsplit('_',1)[0]
+            if not re.match(METABOLITE_ANNOTATIONS[db_id],
+                            str(no_compartment_id)):
+                data[db_id][met] = False
+            else:
+                data[db_id][met] = True
+    return pd.DataFrame.from_dict(data)
+
+
+def collect_rxn_id_namespace(model):
+    """
+    Identify to which common database reaction IDs belong.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    dataframe : pandas.core.frame.DataFrame
+        Table with reaction IDs as rows and database namespaces as the
+        columns. Cell values are boolean.
+
+    """
+    data = {}
+    for db_id in REACTION_ANNOTATIONS:
+        data[db_id] = {}
+        for rxn in model.reactions:
+            if not re.match(REACTION_ANNOTATIONS[db_id],
+                            str(rxn.id)):
+                data[db_id][rxn] = False
+            else:
+                data[db_id][rxn] = True
+    return pd.DataFrame.from_dict(data)

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Supporting functions for annotation checks performed on the model object."""
+
+from __future__ import absolute_import
+
+import logging
+import re
+
+LOGGER = logging.getLogger(__name__)
+
+# MIRIAM (http://www.ebi.ac.uk/miriam/) styled identifiers for
+# common databases that currently included are:
+# DB    rxn,met,gen url
+# 'MetaNetX'  ['rxn','met'] 'http://www.metanetx.org'
+# 'Kegg'  ['rxn','met'] 'http://www.kegg.jp/'
+# 'SEED'  ['met']  'http://modelseed.org/'
+# 'InChIKey'  ['met'] 'http://cactus.nci.nih.gov/chemical/structure'
+# 'ChEBI' ['met'] 'http://bioportal.bioontology.org/ontologies/CHEBI'
+# 'EnzymeNomenclature'    ['rxn'] 'http://www.enzyme-database.org/'
+# 'BRENDA'    ['rxn']    'http://www.brenda-enzymes.org/'
+# 'RHEA'  ['rxn']  'http://www.rhea-db.org/'
+# 'HMDB'  ['met'] 'http://www.hmdb.ca/'
+# 'BioCyc'  ['rxn','met'] 'http://biocyc.org'
+# 'Reactome'    ['met'] 'http://www.reactome.org/'
+# 'BiGG'    ['rxn','met']   'http://bigg.ucsd.edu/universal/'
+
+REACTION_ANNOTATIONS = {'metanetx.reaction': re.compile(r"^MNXR\d+$"),
+                        'kegg.reaction': re.compile(r"^R\d+$"),
+                        'ec-code': re.compile(r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
+                                              r"\d+\.\d+\.\d+\.-|"
+                                              r"\d+\.\d+\.\d+\.(n)?\d+$"),
+                        'brenda': re.compile(r"^\d+\.-\.-\.-|\d+\.\d+\.-\.-|"
+                                             r"\d+\.\d+\.\d+\.-|"
+                                             r"\d+\.\d+\.\d+\.(n)?\d+$"),
+                        'rhea': re.compile(r"^\d{5}$"),
+                        'biocyc': re.compile(r"^[A-Z-0-9]+(?<!CHEBI)"
+                                             r"(\:)?[A-Za-z0-9+_.%-]+$"),
+                        'bigg.reaction': re.compile(r"^[a-z_A-Z0-9]+$")}
+
+
+METABOLITE_ANNOTATIONS = {'metanetx.chemical': re.compile(r"^MNXM\d+$"),
+                          'kegg.compound': re.compile(r"^C\d+$"),
+                          'seed.compound': re.compile(r"^cpd\d+$"),
+                          'inchikey': re.compile(
+                            r"^[A-Z]{14}\-[A-Z]{10}(\-[A-Z])?"
+                            ),
+                          'chebi': re.compile(r"^CHEBI:\d+$"),
+                          'hmdb': re.compile(r"^HMDB\d{5}$"),
+                          'biocyc': re.compile(r"^[A-Z-0-9]+(?<!CHEBI)"
+                                               r"(\:)?[A-Za-z0-9+_.%-]+$"),
+                          'reactome': re.compile(r"(^R-[A-Z]{3}-[0-9]+"
+                                                 r"(-[0-9]+)?$)|"
+                                                 r"(^REACT_\d+(\.\d+)?$)"),
+                          'bigg.metabolite': re.compile(r"^[a-z_A-Z0-9]+$")}
+
+
+def find_met_without_annotations(model):
+    """
+    Find metabolites with empty annotation attributes.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        A cobrapy metabolic model.
+
+    Returns
+    -------
+    list
+        Metabolites that have empty annotation attributes.
+
+    """
+    return [met for met in model.metabolites if met.annotation == {}]

--- a/memote/support/annotation.py
+++ b/memote/support/annotation.py
@@ -199,7 +199,7 @@ def find_wrong_annotation_ids(model, overview_dict, rxn_or_met):
             if type(item.annotation[db_id]) == list:
                 for anno_id in item.annotation[db_id]:
                     if not re.match(
-                        pattern_storage[db_id], anno_id
+                        pattern_storage[db_id], str(anno_id)
                     ):
                         items_anno_wrong_ids[db_id].append(item)
                         break

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -104,7 +104,7 @@ def find_biomass_reaction(model):
     return [rxn for rxn in model.reactions if "biomass" in rxn.id.lower()]
 
 
-def get_difference(subset, model, type):
+def get_difference(subset, model, rxn_or_met):
     """
     Return difference between a given subset and the full set.
 
@@ -121,13 +121,13 @@ def get_difference(subset, model, type):
     model : cobra.Model
         The metabolic model under investigation.
 
-    type : str
+    rxn_or_met : str
         Either 'rxn' or 'met'.
 
     """
-    if type == 'met':
+    if rxn_or_met == 'met':
         diff_subset = set(model.metabolites).difference(set(subset))
-    if type == 'rxn':
+    if rxn_or_met == 'rxn':
         diff_subset = set(model.reactions).difference(set(subset))
     else:
         pass

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 
 import logging
 import re
+from builtins import dict
 
 LOGGER = logging.getLogger(__name__)
 
@@ -104,31 +105,8 @@ def find_biomass_reaction(model):
     return [rxn for rxn in model.reactions if "biomass" in rxn.id.lower()]
 
 
-def get_difference(subset, model, rxn_or_met):
-    """
-    Return difference between a given subset and the full set.
-
-    Providing that all metabolites or reactions in subset have a certain
-    attribute, this function returns the 'leftover' list of the metabolites or
-    reactions from the total amount of metabolites or reactions, i.e. those
-    that do not have this attribute.
-
-    Parameters
-    ----------
-    subset: list
-        A list of either reactions or metabolites with a certain attribute.
-
-    model : cobra.Model
-        The metabolic model under investigation.
-
-    rxn_or_met : str
-        Either 'rxn' or 'met'.
-
-    """
-    if rxn_or_met == 'met':
-        diff_subset = set(model.metabolites).difference(set(subset))
-    if rxn_or_met == 'rxn':
-        diff_subset = set(model.reactions).difference(set(subset))
-    else:
-        pass
-    return list(diff_subset)
+def df2dict(df):
+    """Turn a `pandas.DataFrame` into a `dict` of lists."""
+    blob = dict((key, df[key].tolist()) for key in df.columns)
+    blob["index"] = df.index.tolist()
+    return blob

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -121,6 +121,9 @@ def get_difference(subset, model, type):
     model : cobra.Model
         The metabolic model under investigation.
 
+    type : str
+        Either 'rxn' or 'met'.
+
     """
     if type == 'met':
         diff_subset = set(model.metabolites).difference(set(subset))

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -102,3 +102,30 @@ def find_biomass_reaction(model):
 
     """
     return [rxn for rxn in model.reactions if "biomass" in rxn.id.lower()]
+
+
+def get_difference(subset, model, type):
+    """
+    Return difference between a given subset and the full set.
+
+    Providing that all metabolites or reactions in subset have a certain
+    attribute, this function returns the 'leftover' list of the metabolites or
+    reactions from the total amount of metabolites or reactions, i.e. those
+    that do not have this attribute.
+
+    Parameters
+    ----------
+    subset: list
+        A list of either reactions or metabolites with a certain attribute.
+
+    model : cobra.Model
+        The metabolic model under investigation.
+
+    """
+    if type == 'met':
+        diff_subset = set(model.metabolites).difference(set(subset))
+    if type == 'rxn':
+        diff_subset = set(model.reactions).difference(set(subset))
+    else:
+        pass
+    return list(diff_subset)

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2016 Novo Nordisk Foundation Center for Biosustainability,
+# Technical University of Denmark.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import cobra
+import pytest
+
+import memote.support.annotation as annotation
+
+"""
+Tests ensuring that the functions in `memote.support.annotation` work as
+expected.
+"""
+
+
+def model_builder(name):
+    """Returns a cobra.model built to reflect the required test case"""
+    model = cobra.Model(id_or_model=name, name=name)
+    if name == 'no_annotations':
+        met = cobra.Metabolite(id='met_c', name="Met")
+        met1 = cobra.Metabolite(id='met1_c', name="Met1")
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.add_metabolites({met: -1, met1: 1})
+        model.add_reactions([rxn])
+        return model
+    if name == 'met_annotations':
+        met = cobra.Metabolite(id='met_c', name="Met")
+        met1 = cobra.Metabolite(id='met1_c', name="Met1")
+        met.annotation = {'metanetx.chemical': 'MNXM1235'}
+        met1.annotation = {'ec-code': '1.1.2.3'}
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.add_metabolites({met: -1, met1: 1})
+        model.add_reactions([rxn])
+        return model
+    if name == 'rxn_annotations':
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.annotation = {'brenda': '1.1.1.1'}
+        model.add_reactions([rxn])
+        return model
+
+
+@pytest.mark.parametrize("model, num", [
+    ("no_annotations", 0),
+    ("met_annotations", 2)
+], indirect=["model"])
+def test_mets_without_annotation(model, num):
+    """Expect all mets to have a non-empty annotation attribute"""
+    mets_without_annotation = annotation.find_met_without_annotations(model)
+    assert len(mets_without_annotation) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("no_annotations", 0),
+    ("rxn_annotations", 1)
+], indirect=["model"])
+def test_rxns_without_annotation(model, num):
+    """Expect all rxns to have a non-empty annotation attribute"""
+    rxns_without_annotation = annotation.find_rxn_without_annotations(model)
+    assert len(rxns_without_annotation) == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -237,7 +237,7 @@ def test_find_wrong_annotation_ids(model, num, rxn_or_met):
     ("consistent_ids", 3),
     ("inconsistent_ids", 2)
 ], indirect=["model"])
-def test_met_id_namespace_consistency(model):
+def test_met_id_namespace_consistency(model, num):
     """
     Expect metabolite IDs to be from the same namespace.
     """
@@ -250,14 +250,14 @@ def test_met_id_namespace_consistency(model):
     assert \
         len(
             met_ids_in_each_namespace[met_id_namespace_largest_fraction]
-        ) == len(model.metabolites)
+        ) == num
 
 
 @pytest.mark.parametrize("model, num", [
     ("consistent_ids", 3),
     ("inconsistent_ids", 2)
 ], indirect=["model"])
-def test_rxn_id_namespace_consistency(model):
+def test_rxn_id_namespace_consistency(model, num):
     """
     Expect metabolite IDs to be from the same namespace.
     """
@@ -270,4 +270,4 @@ def test_rxn_id_namespace_consistency(model):
     assert \
         len(
             rxn_ids_in_each_namespace[rxn_id_namespace_largest_fraction]
-        ) == len(model.reactions)
+        ) == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -52,6 +52,50 @@ def model_builder(name):
         rxn.annotation = {'brenda': '1.1.1.1'}
         model.add_reactions([rxn])
         return model
+    if name == 'met_each_present':
+        met = cobra.Metabolite(id='met_c', name="Met")
+        met.annotation = {'metanetx.chemical': "MNXM23",
+                          'kegg.compound': "C00022",
+                          'seed.compound': "cpd00020",
+                          'inchikey': "LCTONWCANYUPML-UHFFFAOYSA-M",
+                          'chebi': ["CHEBI:14987", "CHEBI:15361",
+                                    "CHEBI:26462", "CHEBI:26466",
+                                    "CHEBI:32816", "CHEBI:45253",
+                                    "CHEBI:86354", "CHEBI:8685"],
+                          'hmdb': "HMDB00243",
+                          'biocyc': "META:PYRUVATE",
+                          'reactome': [113557, 29398, 389680],
+                          'bigg.metabolite': "pyr"}
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.add_metabolites({met: -1, met1: 1})
+        model.add_reactions([rxn])
+        return model
+    if name == 'met_each_absent':
+        met = cobra.Metabolite(id='met_c', name="Met")
+        met.annotation = {'METANETX': "MNXM23",
+                          'old_database': "broken_identifier"}
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.add_metabolites({met: -1, met1: 1})
+        model.add_reactions([rxn])
+        return model
+    if name == 'rxn_each_present':
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.annotation = {'metanetx.reaction': "MNXR13125",
+                        'kegg.reaction': "R01068",
+                        'ec-code': "4.1.2.13",
+                        'brenda': "4.1.2.13",
+                        'rhea': [14729, 14730, 14731, 14732],
+                        'biocyc': "ECOLI:F16ALDOLASE-RXN",
+                        'bigg.reaction': "FBA"}
+        model.add_reactions([rxn])
+        return model
+    if name == 'rxn_each_absent':
+    # Old or unknown databases and keys that don't follow the MIRIAM namespaces
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.annotation = {'old_database': "broken_identifier",
+                        'KEGG': "R01068"}
+        model.add_reactions([rxn])
+        return model
 
 
 @pytest.mark.parametrize("model, num", [
@@ -72,3 +116,35 @@ def test_rxns_without_annotation(model, num):
     """Expect all rxns to have a non-empty annotation attribute"""
     rxns_without_annotation = annotation.find_rxn_without_annotations(model)
     assert len(rxns_without_annotation) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("met_each_present", 1),
+    ("met_each_absent", 0)
+], indirect=["model"])
+def test_mets_annotation_overview(model, num):
+    """
+    Expect all mets to have annotations from common databases.
+
+    The required databases are outlined in annotation.py.
+    """
+    met_annotation_overview = \
+        annotation.generate_met_annotation_overview(model)
+    for key in annotation.METABOLITE_ANNOTATIONS:
+        assert met_annotation_overview[key] == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("rxn_each_present", 1),
+    ("rxn_each_absent", 0)
+], indirect=["model"])
+def test_rxns_annotation_overview(model, num):
+    """
+    Expect all rxns to have annotations from common databases.
+
+    The required databases are outlined in annotation.py.
+    """
+    rxn_annotation_overview = \
+        annotation.generate_rxn_annotation_overview(model)
+    for key in annotation.REACTION_ANNOTATIONS:
+        assert rxn_annotation_overview[key] == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -186,22 +186,22 @@ def test_rxns_annotation_overview(model, num):
     ("rxn_each_present", 0, "rxn"),
     ("rxn_broken_id", 1, "rxn")
 ], indirect=["model"])
-def test_find_wrong_annotation_ids(model, num, type):
+def test_find_wrong_annotation_ids(model, num, rxn_or_met):
     """
     Expect all items to have annotations that match MIRIAM patterns.
 
     The required databases and their patterns are outlined in annotation.py.
     """
-    if type == "met":
+    if rxn_or_met == "met":
         item_annotation_overview = \
             annotation.generate_met_annotation_overview(model)
-    if type == "rxn":
+    if rxn_or_met == "rxn":
         item_annotation_overview = \
             annotation.generate_rxn_annotation_overview(model)
     wrong_annotation_ids = annotation.find_wrong_annotation_ids(
         model,
         item_annotation_overview,
-        type
+        rxn_or_met
     )
     for key in wrong_annotation_ids:
         assert len(wrong_annotation_ids[key]) == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -64,7 +64,9 @@ def model_builder(name):
                                     "CHEBI:86354", "CHEBI:8685"],
                           'hmdb': "HMDB00243",
                           'biocyc': "META:PYRUVATE",
-                          'reactome': [113557, 29398, 389680],
+                          'reactome': ["R-ALL-113557",
+                                       "R-ALL-29398",
+                                       "R-ALL-389680"],
                           'bigg.metabolite': "pyr"}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.add_metabolites({met: -1})
@@ -84,7 +86,7 @@ def model_builder(name):
                           'kegg.reaction': "R01068",
                           'ec-code': "4.1.2.13",
                           'brenda': "4.1.2.13",
-                          'rhea': [14729, 14730, 14731, 14732],
+                          'rhea': ["14729", "14730", "14731", "14732"],
                           'biocyc': "ECOLI:F16ALDOLASE-RXN",
                           'bigg.reaction': "FBA"}
         model.add_reactions([rxn])
@@ -109,7 +111,7 @@ def model_builder(name):
                                     "CHEBI:86354", "CHEBI:8685"],
                           'hmdb': "HMBD00243",
                           'biocyc': "META-PYRUVATE",
-                          'reactome': [57, "29398", 389],
+                          'reactome': ["113557", "29398", "389680"],
                           'bigg.metabolite': "324RSF"}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.add_metabolites({met: -1})
@@ -121,7 +123,7 @@ def model_builder(name):
                           'kegg.reaction': "T1068",
                           'ec-code': "4.1.2..13",
                           'brenda': "4.1.2..13",
-                          'rhea': ["14729", 14730, 14731, 14732],
+                          'rhea': ["14729", "14730", "14731", "ABCD"],
                           'biocyc': "ECOLI_F16ALDOLASE-RXN",
                           'bigg.reaction': "2x_FBA"}
         model.add_reactions([rxn])

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -67,7 +67,7 @@ def model_builder(name):
                           'reactome': [113557, 29398, 389680],
                           'bigg.metabolite': "pyr"}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
-        rxn.add_metabolites({met: -1, met1: 1})
+        rxn.add_metabolites({met: -1})
         model.add_reactions([rxn])
         return model
     if name == 'met_each_absent':
@@ -75,25 +75,26 @@ def model_builder(name):
         met.annotation = {'METANETX': "MNXM23",
                           'old_database': "broken_identifier"}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
-        rxn.add_metabolites({met: -1, met1: 1})
+        rxn.add_metabolites({met: -1})
         model.add_reactions([rxn])
         return model
     if name == 'rxn_each_present':
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.annotation = {'metanetx.reaction': "MNXR13125",
-                        'kegg.reaction': "R01068",
-                        'ec-code': "4.1.2.13",
-                        'brenda': "4.1.2.13",
-                        'rhea': [14729, 14730, 14731, 14732],
-                        'biocyc': "ECOLI:F16ALDOLASE-RXN",
-                        'bigg.reaction': "FBA"}
+                          'kegg.reaction': "R01068",
+                          'ec-code': "4.1.2.13",
+                          'brenda': "4.1.2.13",
+                          'rhea': [14729, 14730, 14731, 14732],
+                          'biocyc': "ECOLI:F16ALDOLASE-RXN",
+                          'bigg.reaction': "FBA"}
         model.add_reactions([rxn])
         return model
     if name == 'rxn_each_absent':
-    # Old or unknown databases and keys that don't follow the MIRIAM namespaces
+        # Old or unknown databases and
+        # keys that don't follow the MIRIAM namespaces
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.annotation = {'old_database': "broken_identifier",
-                        'KEGG': "R01068"}
+                          'KEGG': "R01068"}
         model.add_reactions([rxn])
         return model
 

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -97,6 +97,35 @@ def model_builder(name):
                           'KEGG': "R01068"}
         model.add_reactions([rxn])
         return model
+    if name == 'met_broken_id':
+        met = cobra.Metabolite(id='met_c', name="Met")
+        met.annotation = {'metanetx.chemical': "MNXR23",
+                          'kegg.compound': "K00022",
+                          'seed.compound': "cdp00020",
+                          'inchikey': "LCT-ONWCANYUPML-UHFFFAOYSA-M",
+                          'chebi': ["CHEBI:487", "CHEBI:15361",
+                                    "CHEBI:26462", "CHEBI:26466",
+                                    "CHEBI:32816", "CEBI:45253",
+                                    "CHEBI:86354", "CHEBI:8685"],
+                          'hmdb': "HMBD00243",
+                          'biocyc': "META-PYRUVATE",
+                          'reactome': [57, "29398", 389],
+                          'bigg.metabolite': "324RSF"}
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.add_metabolites({met: -1})
+        model.add_reactions([rxn])
+        return model
+    if name == 'rxn_broken_id':
+        rxn = cobra.Reaction(id='RXN', name="Rxn")
+        rxn.annotation = {'metanetx.reaction': "MNXM13125",
+                          'kegg.reaction': "T1068",
+                          'ec-code': "4.1.2..13",
+                          'brenda': "4.1.2..13",
+                          'rhea': ["14729", 14730, 14731, 14732],
+                          'biocyc': "ECOLI_F16ALDOLASE-RXN",
+                          'bigg.reaction': "2x_FBA"}
+        model.add_reactions([rxn])
+        return model
 
 
 @pytest.mark.parametrize("model, num", [
@@ -149,3 +178,30 @@ def test_rxns_annotation_overview(model, num):
         annotation.generate_rxn_annotation_overview(model)
     for key in annotation.REACTION_ANNOTATIONS:
         assert rxn_annotation_overview[key] == num
+
+
+@pytest.mark.parametrize("model, num, type", [
+    ("met_each_present", 1, "met"),
+    ("met_broken_id", 0, "met"),
+    ("rxn_each_present", 1, "rxn"),
+    ("rxn_broken_id", 0, "rxn")
+], indirect=["model"])
+def test_find_wrong_annotation_ids(model, num, type):
+    """
+    Expect all items to have annotations that match MIRIAM patterns.
+
+    The required databases and their patterns are outlined in annotation.py.
+    """
+    if type == "met":
+        item_annotation_overview = \
+            annotation.generate_met_annotation_overview(model)
+    if type == "rxn":
+        item_annotation_overview = \
+            annotation.generate_rxn_annotation_overview(model)
+    wrong_annotation_ids = annotation.find_wrong_annotation_ids(
+        model,
+        item_annotation_overview,
+        type
+    )
+    for key in wrong_annotation_ids:
+        assert wrong_annotation_ids[key] == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -129,8 +129,8 @@ def model_builder(name):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("no_annotations", 0),
-    ("met_annotations", 2)
+    ("no_annotations", 2),
+    ("met_annotations", 0)
 ], indirect=["model"])
 def test_mets_without_annotation(model, num):
     """Expect all mets to have a non-empty annotation attribute"""
@@ -139,8 +139,8 @@ def test_mets_without_annotation(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("no_annotations", 0),
-    ("rxn_annotations", 1)
+    ("no_annotations", 1),
+    ("rxn_annotations", 0)
 ], indirect=["model"])
 def test_rxns_without_annotation(model, num):
     """Expect all rxns to have a non-empty annotation attribute"""
@@ -149,8 +149,8 @@ def test_rxns_without_annotation(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    ("met_each_present", 1),
-    ("met_each_absent", 0)
+    ("met_each_present", 0),
+    ("met_each_absent", 1)
 ], indirect=["model"])
 def test_mets_annotation_overview(model, num):
     """
@@ -161,12 +161,12 @@ def test_mets_annotation_overview(model, num):
     met_annotation_overview = \
         annotation.generate_met_annotation_overview(model)
     for key in annotation.METABOLITE_ANNOTATIONS:
-        assert met_annotation_overview[key] == num
+        assert len(met_annotation_overview[key]) == num
 
 
 @pytest.mark.parametrize("model, num", [
-    ("rxn_each_present", 1),
-    ("rxn_each_absent", 0)
+    ("rxn_each_present", 0),
+    ("rxn_each_absent", 1)
 ], indirect=["model"])
 def test_rxns_annotation_overview(model, num):
     """
@@ -177,14 +177,14 @@ def test_rxns_annotation_overview(model, num):
     rxn_annotation_overview = \
         annotation.generate_rxn_annotation_overview(model)
     for key in annotation.REACTION_ANNOTATIONS:
-        assert rxn_annotation_overview[key] == num
+        assert len(rxn_annotation_overview[key]) == num
 
 
 @pytest.mark.parametrize("model, num, type", [
-    ("met_each_present", 1, "met"),
-    ("met_broken_id", 0, "met"),
-    ("rxn_each_present", 1, "rxn"),
-    ("rxn_broken_id", 0, "rxn")
+    ("met_each_present", 0, "met"),
+    ("met_broken_id", 1, "met"),
+    ("rxn_each_present", 0, "rxn"),
+    ("rxn_broken_id", 1, "rxn")
 ], indirect=["model"])
 def test_find_wrong_annotation_ids(model, num, type):
     """
@@ -204,4 +204,4 @@ def test_find_wrong_annotation_ids(model, num, type):
         type
     )
     for key in wrong_annotation_ids:
-        assert wrong_annotation_ids[key] == num
+        assert len(wrong_annotation_ids[key]) == num

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -180,7 +180,7 @@ def test_rxns_annotation_overview(model, num):
         assert len(rxn_annotation_overview[key]) == num
 
 
-@pytest.mark.parametrize("model, num, type", [
+@pytest.mark.parametrize("model, num, rxn_or_met", [
     ("met_each_present", 0, "met"),
     ("met_broken_id", 1, "met"),
     ("rxn_each_present", 0, "rxn"),

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -110,7 +110,7 @@ def model_builder(name):
                                     "CHEBI:32816", "CEBI:O",
                                     "CHEBI:86354", "CHEBI:8685"],
                           'hmdb': "HMBD00243",
-                          'biocyc': "-PYRUVATE",
+                          'biocyc': "/:PYRUVATE",
                           'reactome': ["113557", "29398", "389680"],
                           'bigg.metabolite': ""}
         rxn = cobra.Reaction(id='RXN', name="Rxn")

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -107,12 +107,12 @@ def model_builder(name):
                           'inchikey': "LCT-ONWCANYUPML-UHFFFAOYSA-M",
                           'chebi': ["CHEBI:487", "CHEBI:15361",
                                     "CHEBI:26462", "CHEBI:26466",
-                                    "CHEBI:32816", "CEBI:45253",
+                                    "CHEBI:32816", "CEBI:O",
                                     "CHEBI:86354", "CHEBI:8685"],
                           'hmdb': "HMBD00243",
-                          'biocyc': "META-PYRUVATE",
+                          'biocyc': "-PYRUVATE",
                           'reactome': ["113557", "29398", "389680"],
-                          'bigg.metabolite': "324RSF"}
+                          'bigg.metabolite': ":324RSF"}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.add_metabolites({met: -1})
         model.add_reactions([rxn])
@@ -123,9 +123,9 @@ def model_builder(name):
                           'kegg.reaction': "T1068",
                           'ec-code': "4.1.2..13",
                           'brenda': "4.1.2..13",
-                          'rhea': ["14729", "14730", "14731", "ABCD"],
-                          'biocyc': "ECOLI_F16ALDOLASE-RXN",
-                          'bigg.reaction': "2x_FBA"}
+                          'rhea': ["1472999", "14730", "14731", "ABCD"],
+                          'biocyc': ":ECOLI_F16ALDOLASE-RXN",
+                          'bigg.reaction': "/:2x_FBA"}
         model.add_reactions([rxn])
         return model
 

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -233,9 +233,9 @@ def test_find_wrong_annotation_ids(model, num, rxn_or_met):
         assert len(wrong_annotation_ids[key]) == num
 
 
-@pytest.mark.parametrize("model", [
-    "consistent_ids",
-    "inconsistent_ids"
+@pytest.mark.parametrize("model, num", [
+    ("consistent_ids", 3),
+    ("inconsistent_ids", 2)
 ], indirect=["model"])
 def test_met_id_namespace_consistency(model):
     """
@@ -253,9 +253,9 @@ def test_met_id_namespace_consistency(model):
         ) == len(model.metabolites)
 
 
-@pytest.mark.parametrize("model", [
-    "consistent_ids",
-    "inconsistent_ids"
+@pytest.mark.parametrize("model, num", [
+    ("consistent_ids", 3),
+    ("inconsistent_ids", 2)
 ], indirect=["model"])
 def test_rxn_id_namespace_consistency(model):
     """

--- a/tests/test_for_support/test_for_annotation.py
+++ b/tests/test_for_support/test_for_annotation.py
@@ -112,7 +112,7 @@ def model_builder(name):
                           'hmdb': "HMBD00243",
                           'biocyc': "-PYRUVATE",
                           'reactome': ["113557", "29398", "389680"],
-                          'bigg.metabolite': ":324RSF"}
+                          'bigg.metabolite': ""}
         rxn = cobra.Reaction(id='RXN', name="Rxn")
         rxn.add_metabolites({met: -1})
         model.add_reactions([rxn])


### PR DESCRIPTION
resolves #33 

This PR includes a couple of new checks and tests.

First of all when I refer to 'items' I mean either metabolites or reactions.

1. I am adding `annotation.py`, which contains:
`REACTION_ANNOTATIONS` : A dictionary mapping MIRIAM-style reaction database namespaces against the corresponding identifier patterns as compiled regex patterns.
METABOLITE_ANNOTATIONS` : A dictionary mapping MIRIAM-style metabolite database namespaces against the corresponding identifier patterns as compiled regex patterns.

I selected the included databases more or less from experience, i.e. what I had seen to be commonly referenced in metabolic models. I am open for input on what are or aren't 'must-have' databases.

In addition to these two dictionaries, `annotation.py` contains functions to list items without annotation, list items without annotations of each specific database, list items that do contain annotations of a specific database, but which identifiers do not match the corresponding regex pattern.

2. `test_annotation.py`:
Contains annotation specific tests for a given model.
We expect that no item is without annotation, that all items have annotations from all databases and that the identifiers of all of those databases are correct.

3. `test_for_annotation.py`:
Contains test for the code in `annotation.py`.
We expect that no item is without annotation, that all items have annotations from all databases and that the identifiers of all of those databases are correct.