### PR TITLE
Basic metrics

### DIFF
--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -64,13 +64,12 @@ def test_metabolites_formula_presence(read_only_model, store):
 
 def test_gene_protein_reaction_rule_presence(read_only_model, store):
     """Expect all non-exchange reactions to have a GPR."""
-    missing_gpr = [
-        rxn.id for rxn in basic.check_gene_protein_reaction_rule_presence(
-            read_only_model
-        )
-    ]
     missing_gpr_metabolic_rxns = \
-        set(missing_gpr).difference(set(read_only_model.exchanges))
-    store["reactions_no_GPR"] = missing_gpr_metabolic_rxns
-    assert len(missing_gpr_metabolic_rxns) == 0, "No GPR found for the " \
+        set(
+            basic.check_gene_protein_reaction_rule_presence(
+                read_only_model
+            )
+        ).difference(set(read_only_model.exchanges))
+    store["reactions_no_GPR"] = [rxn.id for rxn in missing_gpr_metabolic_rxns]
+    assert len(store["reactions_no_GPR"]) == 0, "No GPR found for the " \
         "following reactions: {}".format(", ".join(missing_gpr_metabolic_rxns))

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -89,5 +89,6 @@ def test_gene_protein_reaction_rule_presence(read_only_model, store):
 
 def test_metabolic_coverage(read_only_model, store):
     """Expect a model to have high metabolic coverage."""
-    store("metabolic_coverage") = basic.calculate_metabolic_coverage(read_only_model)
-    assert store("metabolic_coverage") >= 1
+    store["metabolic_coverage"] = \
+        basic.calculate_metabolic_coverage(read_only_model)
+    assert store["metabolic_coverage"] >= 1

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -19,7 +19,7 @@
 
 from __future__ import absolute_import
 
-from memote.support.basic import check_metabolites_formula_presence
+import memote.support.basic as basic
 
 
 def test_model_id_presence(read_only_model, store):
@@ -53,7 +53,24 @@ def test_metabolites_presence(read_only_model, store):
 def test_metabolites_formula_presence(read_only_model, store):
     """Expect all metabolites to have a formula."""
     missing = [
-        met.id for met in check_metabolites_formula_presence(read_only_model)]
+        met.id for met in basic.check_metabolites_formula_presence(
+            read_only_model
+        )
+    ]
     store["metabolites_no_formula"] = missing
     assert len(missing) == 0, "No formula found for the following "\
         "metabolites: {}".format(", ".join(missing))
+
+
+def test_gene_protein_reaction_rule_presence(read_only_model, store):
+    """Expect all non-exchange reactions to have a GPR."""
+    missing_gpr = [
+        rxn.id for rxn in basic.check_gene_protein_reaction_rule_presence(
+            read_only_model
+        )
+    ]
+    missing_gpr_metabolic_rxns = \
+        set(missing_gpr).difference(set(read_only_model.exchanges))
+    store["reactions_no_GPR"] = missing_gpr_metabolic_rxns
+    assert len(missing_gpr_metabolic_rxns) == 0, "No GPR found for the " \
+        "following reactions: {}".format(", ".join(missing_gpr_metabolic_rxns))

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -85,3 +85,9 @@ def test_gene_protein_reaction_rule_presence(read_only_model, store):
     store["reactions_no_GPR"] = [rxn.id for rxn in missing_gpr_metabolic_rxns]
     assert len(store["reactions_no_GPR"]) == 0, "No GPR found for the " \
         "following reactions: {}".format(", ".join(missing_gpr_metabolic_rxns))
+
+
+def test_metabolic_coverage(read_only_model, store):
+    """Expect a model to have high metabolic coverage."""
+    store("metabolic_coverage") = basic.calculate_metabolic_coverage(read_only_model)
+    assert store("metabolic_coverage") >= 1

--- a/memote/suite/tests/test_basic.py
+++ b/memote/suite/tests/test_basic.py
@@ -62,6 +62,18 @@ def test_metabolites_formula_presence(read_only_model, store):
         "metabolites: {}".format(", ".join(missing))
 
 
+def test_metabolites_charge_presence(read_only_model, store):
+    """Expect all metabolites to have a formula."""
+    missing = [
+        met.id for met in basic.check_metabolites_charge_presence(
+            read_only_model
+        )
+    ]
+    store["metabolites_no_charge"] = missing
+    assert len(missing) == 0, "No charge found for the following "\
+        "metabolites: {}".format(", ".join(missing))
+
+
 def test_gene_protein_reaction_rule_presence(read_only_model, store):
     """Expect all non-exchange reactions to have a GPR."""
     missing_gpr_metabolic_rxns = \

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -85,5 +85,6 @@ def calculate_metabolic_coverage(model):
     [1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing genome-scale
     network reconstructions. Nature Biotechnology, 32(5), 447–452.
     http://doi.org/10.1038/nbt.2870
+    
     """
     return float(len(model.reactions)) / float(len(model.genes))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -32,6 +32,11 @@ def check_metabolites_formula_presence(model):
     return [met for met in model.metabolites if not met.formula]
 
 
+def check_metabolites_charge_presence(model):
+    """Return the list of model metabolites that have no associated charge."""
+    return [met for met in model.metabolites if not type(met.charge) == int]
+
+
 def check_gene_protein_reaction_rule_presence(model):
     """Return the list of model reactions that have no associated gene rule."""
     return [rxn for rxn in model.reactions if not rxn.gene_reaction_rule]

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -29,12 +29,12 @@ LOGGER = logging.getLogger(__name__)
 
 def check_metabolites_formula_presence(model):
     """Return the list of model metabolites that have no associated formula."""
-    return [met for met in model.metabolites if not met.formula]
+    return [met for met in model.metabolites if met.formula is None]
 
 
 def check_metabolites_charge_presence(model):
     """Return the list of model metabolites that have no associated charge."""
-    return [met for met in model.metabolites if not type(met.charge) == int]
+    return [met for met in model.metabolites if met.charge is None]
 
 
 def check_gene_protein_reaction_rule_presence(model):
@@ -87,4 +87,6 @@ def calculate_metabolic_coverage(model):
     http://doi.org/10.1038/nbt.2870
 
     """
+    if len(model.reactions) == 0 or len(model.genes) == 0:
+        raise ValueError("The model contains no reactions or genes.")
     return float(len(model.reactions)) / float(len(model.genes))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -32,6 +32,6 @@ def check_metabolites_formula_presence(model):
     return [met for met in model.metabolites if not met.formula]
 
 
-def check_gene_reaction_rule_presence(model):
+def check_gene_protein_reaction_rule_presence(model):
     """Return the list of model reactions that have no associated gene rule."""
     return [rxn for rxn in model.reactions if not rxn.gene_reaction_rule]

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -85,6 +85,6 @@ def calculate_metabolic_coverage(model):
     [1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing genome-scale
     network reconstructions. Nature Biotechnology, 32(5), 447–452.
     http://doi.org/10.1038/nbt.2870
-    
+
     """
     return float(len(model.reactions)) / float(len(model.genes))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -40,3 +40,29 @@ def check_metabolites_charge_presence(model):
 def check_gene_protein_reaction_rule_presence(model):
     """Return the list of model reactions that have no associated gene rule."""
     return [rxn for rxn in model.reactions if not rxn.gene_reaction_rule]
+
+
+def find_nonzero_constrained_reactions(model):
+    """Return list of reactions with non-zero, non-maximal bounds."""
+    return [rxn for rxn in model.reactions if
+            0 < rxn.lower_bound > -1000 or
+            0 > rxn.upper_bound < 1000]
+
+
+def find_zero_constrained_reactions(model):
+    """Return list of reactions that are constrained to zero flux."""
+    return [rxn for rxn in model.reactions if
+            rxn.lower_bound == 0 and
+            rxn.upper_bound == 0]
+
+
+def find_irreversible_reactions(model):
+    """Return list of reactions that are irreversible."""
+    return [rxn for rxn in model.reactions if rxn.reversibility == False]
+
+
+def find_unconstrained_reactions(model):
+    """Return list of reactions that are not constrained at all."""
+    return [rxn for rxn in model.reactions if
+            rxn.lower_bound <= -1000 and
+            rxn.upper_bound >= 1000]

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -45,8 +45,8 @@ def check_gene_protein_reaction_rule_presence(model):
 def find_nonzero_constrained_reactions(model):
     """Return list of reactions with non-zero, non-maximal bounds."""
     return [rxn for rxn in model.reactions if
-            0 < rxn.lower_bound > -1000 or
-            0 > rxn.upper_bound < 1000]
+            0 > rxn.lower_bound > -1000 or
+            0 < rxn.upper_bound < 1000]
 
 
 def find_zero_constrained_reactions(model):

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -70,7 +70,7 @@ def find_unconstrained_reactions(model):
 
 def calculate_metabolic_coverage(model):
     """
-    Return the ratio of reactions and genes included in the model
+    Return the ratio of reactions and genes included in the model.
 
     According to [1] this is a good quality indicator expressing the degree of
     metabolic coverage i.e. modeling detail of a given reconstruction. The
@@ -86,5 +86,4 @@ def calculate_metabolic_coverage(model):
     network reconstructions. Nature Biotechnology, 32(5), 447–452.
     http://doi.org/10.1038/nbt.2870
     """
-
     return float(len(model.reactions)) / float(len(model.genes))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -30,3 +30,8 @@ LOGGER = logging.getLogger(__name__)
 def check_metabolites_formula_presence(model):
     """Return the list of model metabolites that have no associated formula."""
     return [met for met in model.metabolites if not met.formula]
+
+
+def check_gene_reaction_rule_presence(model):
+    """Return the list of model reactions that have no associated gene rule."""
+    return [rxn for rxn in model.reactions if not rxn.gene_reaction_rule]

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -66,3 +66,25 @@ def find_unconstrained_reactions(model):
     return [rxn for rxn in model.reactions if
             rxn.lower_bound <= -1000 and
             rxn.upper_bound >= 1000]
+
+
+def calculate_metabolic_coverage(model):
+    """
+    Return the ratio of reactions and genes included in the model
+
+    According to [1] this is a good quality indicator expressing the degree of
+    metabolic coverage i.e. modeling detail of a given reconstruction. The
+    authors explain that models with a 'high level of modeling detail have
+    ratios >1, and [models] with low level of detail have ratios <1'. They
+    explain that 'this difference arises because [models] with basic or
+    intermediate levels of detail often include many reactions in which several
+    gene products and their enzymatic transformations are ‘lumped’'.
+
+    References
+    ----------
+    [1] Monk, J., Nogales, J., & Palsson, B. O. (2014). Optimizing genome-scale
+    network reconstructions. Nature Biotechnology, 32(5), 447–452.
+    http://doi.org/10.1038/nbt.2870
+    """
+
+    return float(len(model.reactions)) / float(len(model.genes))

--- a/memote/support/basic.py
+++ b/memote/support/basic.py
@@ -58,7 +58,7 @@ def find_zero_constrained_reactions(model):
 
 def find_irreversible_reactions(model):
     """Return list of reactions that are irreversible."""
-    return [rxn for rxn in model.reactions if rxn.reversibility == False]
+    return [rxn for rxn in model.reactions if rxn.reversibility is False]
 
 
 def find_unconstrained_reactions(model):

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -8,7 +8,8 @@ tox
 coverage
 Sphinx
 PyYAML
-pytest
+pytest>=3.1
+pytest-raises
 pytest-cov
 codecov
 travis-encrypt

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requirements = [
     "click-configfile",
     "colorama",
     "future",
-    "pytest",
+    "pytest>=3.1",
     "gitpython",
     "pandas>=0.20.1",
     "dask>=0.14.3",
@@ -56,7 +56,8 @@ requirements = [
 ]
 
 test_requirements = [
-    "pytest"
+    "pytest>=3.1"
+    "pytest-raises"
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,6 @@ from optlang import available_solvers
 from cobra import Model
 from cobra.io import read_sbml_model
 
-import memote
-
 """
 Configuration and fixtures for the py.test suite.
 """

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -154,8 +154,11 @@ def nonzero_constrained_rxn():
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
+    rxn_2 = cobra.Reaction("RXN2")
+    rxn_2.add_metabolites({met_1: -1, met_2: 1})
     rxn_1.bounds = 0, 5
-    model.add_reactions([rxn_1])
+    rxn_2.bounds = -5, 0
+    model.add_reactions([rxn_1, rxn_2])
     return model
 
 

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -59,7 +59,7 @@ def gpr_present():
     rxn_1.gene_reaction_rule = 'gene1 and gene2'
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
-    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    rxn_1.add_metabolites({met_1: 1, met_2: -1})
     model.add_reactions([rxn_1])
     return model
 
@@ -71,7 +71,7 @@ def gpr_missing():
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
-    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    rxn_1.add_metabolites({met_1: 1, met_2: -1})
     model.add_reactions([rxn_1])
     return model
 
@@ -86,7 +86,7 @@ def gpr_present_with_exchange():
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
-    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    rxn_1.add_metabolites({met_1: 1, met_2: -1})
     rxn_2 = cobra.Reaction("EX_met1_c")
     met_1 = cobra.Metabolite("met1")
     rxn_2.add_metabolites({met_1: 1})
@@ -101,6 +101,15 @@ def gpr_present_with_exchange():
 ], indirect=["model"])
 def test_metabolites_formula_presence(model, num):
     assert len(basic.check_metabolites_formula_presence(model)) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("empty", 0),
+    ("three-missing", 3),
+    ("three-present", 0)
+], indirect=["model"])
+def test_metabolites_charge_presence(model, num):
+    assert len(basic.check_metabolites_charge_presence(model)) == num
 
 
 @pytest.mark.parametrize("model, num", [

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -51,6 +51,49 @@ def model_builder(name):
     return choices[name](model)
 
 
+@pytest.fixture(scope="function")
+def gpr_present():
+    """Provide a model with reactions that all have GPR"""
+    model = cobra.Model(id_or_model="gpr_present", name="gpr_present")
+    rxn_1 = cobra.Reaction("RXN1")
+    rxn_1.gene_reaction_rule = 'gene1 and gene2'
+    met_1 = cobra.Metabolite("met1")
+    met_2 = cobra.Metabolite("met2")
+    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    model.add_reactions([rxn_1])
+    return model
+
+
+@pytest.fixture(scope="function")
+def gpr_missing():
+    """Provide a model reactions that lack GPR"""
+    model = cobra.Model(id_or_model="gpr_missing", name="gpr_missing")
+    rxn_1 = cobra.Reaction("RXN1")
+    met_1 = cobra.Metabolite("met1")
+    met_2 = cobra.Metabolite("met2")
+    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    model.add_reactions([rxn_1])
+    return model
+
+
+@pytest.fixture(scope="function")
+def gpr_present_with_exchange():
+    """Provide a model reactions that lack GPR"""
+    model = cobra.Model(
+        id_or_model="gpr_present_with_exchange",
+        name="gpr_present_with_exchange"
+    )
+    rxn_1 = cobra.Reaction("RXN1")
+    met_1 = cobra.Metabolite("met1")
+    met_2 = cobra.Metabolite("met2")
+    rxn_1.add_metabolites({met_1:1,met_2:-1})
+    rxn_2 = cobra.Reaction("EX_met1_c")
+    met_1 = cobra.Metabolite("met1")
+    rxn_2.add_metabolites({met_1: 1})
+    model.add_reactions([rxn_1, rxn_2])
+    return model
+
+
 @pytest.mark.parametrize("model, num", [
     ("empty", 0),
     ("three-missing", 3),
@@ -58,3 +101,19 @@ def model_builder(name):
 ], indirect=["model"])
 def test_metabolites_formula_presence(model, num):
     assert len(basic.check_metabolites_formula_presence(model)) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    (gpr_present(), 0),
+    (gpr_missing(), 1),
+    (gpr_present_with_exchange(), 1),
+])
+def test_gene_protein_reaction_rule_presence(model, num):
+    """Expect all non-exchange reactions to have a GPR."""
+    missing_gpr_metabolic_rxns = \
+        set(
+            basic.check_gene_protein_reaction_rule_presence(
+                model
+            )
+        ).difference(set(model.exchanges))
+    assert len(missing_gpr_metabolic_rxns) == num

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -210,7 +210,7 @@ def test_metabolic_coverage(model, coverage):
 
 @pytest.mark.parametrize("model, num", [
     (unconstrained_rxn(), 0),
-    (nonzero_constrained_rxn(), 1),
+    (nonzero_constrained_rxn(), 2),
 ])
 def test_find_nonzero_constrained_reactions(model, num):
     """Expect amount of non-zero rxns to be identified correctly."""

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -110,7 +110,7 @@ def gpr_present_not_lumped():
 @pytest.fixture(scope="function")
 def unconstrained_rxn():
     """Provide a model with one unconstrained reaction"""
-    model = cobra.Model(id_or_model="model", name="model")
+    model = cobra.Model(id_or_model="unconstrained", name="unconstrained")
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
@@ -123,7 +123,7 @@ def unconstrained_rxn():
 @pytest.fixture(scope="function")
 def irreversible_rxn():
     """Provide a model with one irreversible reaction"""
-    model = cobra.Model(id_or_model="model", name="model")
+    model = cobra.Model(id_or_model="irreversible", name="irreversible")
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
@@ -136,7 +136,9 @@ def irreversible_rxn():
 @pytest.fixture(scope="function")
 def zero_constrained_rxn():
     """Provide a model with one zero-constrained reaction"""
-    model = cobra.Model(id_or_model="model", name="model")
+    model = cobra.Model(
+        id_or_model="zero_constrained", name="zero_constrained"
+    )
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
@@ -149,7 +151,9 @@ def zero_constrained_rxn():
 @pytest.fixture(scope="function")
 def nonzero_constrained_rxn():
     """Provide a model with one nonzero-constrained reaction"""
-    model = cobra.Model(id_or_model="model", name="model")
+    model = cobra.Model(
+        id_or_model="nonzero_constrained", name="nonzero_constrained"
+    )
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")

--- a/tests/test_for_support/test_for_basic.py
+++ b/tests/test_for_support/test_for_basic.py
@@ -36,53 +36,35 @@ def three_missing(base):
 
 def three_present(base):
     base.add_metabolites(
-        [cobra.Metabolite(id="M{0:d}".format(i), formula="CH4")
+        [cobra.Metabolite(id="M{0:d}".format(i), formula="CH4", charge=-1)
          for i in range(1, 4)]
     )
     return base
 
 
-def model_builder(name):
-    choices = {
-        "three-missing": three_missing,
-        "three-present": three_present,
-    }
-    model = cobra.Model(id_or_model=name, name=name)
-    return choices[name](model)
-
-
-@pytest.fixture(scope="function")
-def gpr_present():
+def gpr_present(base):
     """Provide a model with reactions that all have GPR"""
-    model = cobra.Model(id_or_model="gpr_present", name="gpr_present")
     rxn_1 = cobra.Reaction("RXN1")
     rxn_1.gene_reaction_rule = 'gene1 or gene2'
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def gpr_missing():
+def gpr_missing(base):
     """Provide a model reactions that lack GPR"""
-    model = cobra.Model(id_or_model="gpr_missing", name="gpr_missing")
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def gpr_missing_with_exchange():
+def gpr_missing_with_exchange(base):
     """Provide a model reactions that lack GPR"""
-    model = cobra.Model(
-        id_or_model="gpr_missing_with_exchange",
-        name="gpr_missing_with_exchange"
-    )
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
@@ -90,70 +72,56 @@ def gpr_missing_with_exchange():
     rxn_2 = cobra.Reaction("EX_met1_c")
     met_1 = cobra.Metabolite("met1")
     rxn_2.add_metabolites({met_1: 1})
-    model.add_reactions([rxn_1, rxn_2])
-    return model
+    base.add_reactions([rxn_1, rxn_2])
+    return base
 
 
-@pytest.fixture(scope="function")
-def gpr_present_not_lumped():
+def gpr_present_not_lumped(base):
     """Provide a model with reactions that all have GPR"""
-    model = cobra.Model(id_or_model="gpr_present", name="gpr_present")
     rxn_1 = cobra.Reaction("RXN1")
     rxn_1.gene_reaction_rule = 'gene1'
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def unconstrained_rxn():
+def unconstrained_rxn(base):
     """Provide a model with one unconstrained reaction"""
-    model = cobra.Model(id_or_model="unconstrained", name="unconstrained")
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
     rxn_1.bounds = -1000, 1000
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def irreversible_rxn():
+def irreversible_rxn(base):
     """Provide a model with one irreversible reaction"""
-    model = cobra.Model(id_or_model="irreversible", name="irreversible")
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
     rxn_1.bounds = 0, 1000
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def zero_constrained_rxn():
+def zero_constrained_rxn(base):
     """Provide a model with one zero-constrained reaction"""
-    model = cobra.Model(
-        id_or_model="zero_constrained", name="zero_constrained"
-    )
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
     rxn_1.add_metabolites({met_1: 1, met_2: -1})
     rxn_1.bounds = 0, 0
-    model.add_reactions([rxn_1])
-    return model
+    base.add_reactions([rxn_1])
+    return base
 
 
-@pytest.fixture(scope="function")
-def nonzero_constrained_rxn():
+def nonzero_constrained_rxn(base):
     """Provide a model with one nonzero-constrained reaction"""
-    model = cobra.Model(
-        id_or_model="nonzero_constrained", name="nonzero_constrained"
-    )
     rxn_1 = cobra.Reaction("RXN1")
     met_1 = cobra.Metabolite("met1")
     met_2 = cobra.Metabolite("met2")
@@ -162,8 +130,25 @@ def nonzero_constrained_rxn():
     rxn_2.add_metabolites({met_1: -1, met_2: 1})
     rxn_1.bounds = 0, 5
     rxn_2.bounds = -5, 0
-    model.add_reactions([rxn_1, rxn_2])
-    return model
+    base.add_reactions([rxn_1, rxn_2])
+    return base
+
+
+def model_builder(name):
+    choices = {
+        "three-missing": three_missing,
+        "three-present": three_present,
+        "gpr_present": gpr_present,
+        "gpr_missing": gpr_missing,
+        "gpr_missing_with_exchange": gpr_missing_with_exchange,
+        "gpr_present_not_lumped": gpr_present_not_lumped,
+        "unconstrained_rxn": unconstrained_rxn,
+        "irreversible_rxn": irreversible_rxn,
+        "zero_constrained_rxn": zero_constrained_rxn,
+        "nonzero_constrained_rxn": nonzero_constrained_rxn,
+    }
+    model = cobra.Model(id_or_model=name, name=name)
+    return choices[name](model)
 
 
 @pytest.mark.parametrize("model, num", [
@@ -187,10 +172,11 @@ def test_metabolites_charge_presence(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    (gpr_present(), 0),
-    (gpr_missing(), 1),
-    (gpr_missing_with_exchange(), 1),
-])
+    ("empty", 0),
+    ("gpr_present", 0),
+    ("gpr_missing", 1),
+    ("gpr_missing_with_exchange", 1),
+], indirect=["model"])
 def test_gene_protein_reaction_rule_presence(model, num):
     """Expect all non-exchange reactions to have a GPR."""
     missing_gpr_metabolic_rxns = \
@@ -203,9 +189,11 @@ def test_gene_protein_reaction_rule_presence(model, num):
 
 
 @pytest.mark.parametrize("model, coverage", [
-    (gpr_present(), 0.5),
-    (gpr_present_not_lumped(), 1),
-])
+    pytest.param("empty", 0,
+                 marks=pytest.mark.raises(exception=ValueError)),
+    ("gpr_present", 0.5),
+    ("gpr_present_not_lumped", 1),
+], indirect=["model"])
 def test_metabolic_coverage(model, coverage):
     """Expect a model to have high metabolic coverage."""
     metabolic_coverage = basic.calculate_metabolic_coverage(model)
@@ -213,9 +201,10 @@ def test_metabolic_coverage(model, coverage):
 
 
 @pytest.mark.parametrize("model, num", [
-    (unconstrained_rxn(), 0),
-    (nonzero_constrained_rxn(), 2),
-])
+    ("empty", 0),
+    ("unconstrained_rxn", 0),
+    ("nonzero_constrained_rxn", 2),
+], indirect=["model"])
 def test_find_nonzero_constrained_reactions(model, num):
     """Expect amount of non-zero rxns to be identified correctly."""
     nonzero_constrained_rxns = basic.find_nonzero_constrained_reactions(model)
@@ -223,9 +212,10 @@ def test_find_nonzero_constrained_reactions(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    (unconstrained_rxn(), 0),
-    (zero_constrained_rxn(), 1),
-])
+    ("empty", 0),
+    ("unconstrained_rxn", 0),
+    ("zero_constrained_rxn", 1),
+], indirect=["model"])
 def test_find_zero_constrained_reactions(model, num):
     """Expect amount of zero-constrained rxns to be identified correctly."""
     zero_constrained_rxns = basic.find_zero_constrained_reactions(model)
@@ -233,9 +223,10 @@ def test_find_zero_constrained_reactions(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    (unconstrained_rxn(), 0),
-    (irreversible_rxn(), 1),
-])
+    ("empty", 0),
+    ("unconstrained_rxn", 0),
+    ("irreversible_rxn", 1),
+], indirect=["model"])
 def test_find_irreversible_reactions(model, num):
     """Expect amount of irreversible rxns to be identified correctly."""
     irreversible_rxns = basic.find_irreversible_reactions(model)
@@ -243,9 +234,10 @@ def test_find_irreversible_reactions(model, num):
 
 
 @pytest.mark.parametrize("model, num", [
-    (unconstrained_rxn(), 1),
-    (zero_constrained_rxn(), 0),
-])
+    ("empty", 0),
+    ("unconstrained_rxn", 1),
+    ("zero_constrained_rxn", 0),
+], indirect=["model"])
 def test_find_unconstrained_reactions(model, num):
     """Expect amount of unconstrained rxns to be identified correctly."""
     unconstrained_rxns = basic.find_unconstrained_reactions(model)

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,8 @@ skip_missing_interpreters = True
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/memote
 deps =
-    pytest
+    pytest>=3.1
+    pytest-raises
     pytest-cov
     codecov
 passenv =


### PR DESCRIPTION
closes #107, closes #106, closes #61, closes #67 

In this PR, I covered the remaining basic tests outlined in the [Test Catalogue](https://github.com/biosustain/memote/wiki) that don't require file IO (.gbk or similar).

As for issue #67, this PR implements the necessary functions to identify which reactions are unconstrained, irreversible, zero-constrained (lb = ub =0) and non-zero-constrained ( 0 < lb | ub < 1000), but doesn't include any tests that require a certain number/ distribution. While this information is useful when working with a model, I don't think that we need to require any fixed values here. The discussion about whether there should be tests for this or merely a listing in the report can be found here [#67](https://github.com/biosustain/memote/issues/67).