### PR TITLE
fix: repair `test_biomass` parametrized test functions

### DIFF
--- a/memote/suite/collect.py
+++ b/memote/suite/collect.py
@@ -39,6 +39,7 @@ with warnings.catch_warnings():
     from cobra.io import read_sbml_model
 
 from memote.suite.reporting.reports import BasicReport
+from memote.support.helpers import find_biomass_reaction
 
 LOGGER = logging.getLogger(__name__)
 
@@ -100,6 +101,10 @@ class ResultCollectionPlugin(object):
         self.repo = repo
         self.branch = branch
         self.commit = commit
+        # TODO: record SBML warnings and add them to the report
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            self._sbml_model = read_sbml_model(self._model)
 
     def _git_meta_info(self):
         """Record repository meta information."""
@@ -128,15 +133,19 @@ class ResultCollectionPlugin(object):
     @pytest.fixture(scope="session")
     def read_only_model(self):
         """Provide the model for the complete test session."""
-        # TODO: record SBML warnings and add them to the report
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", UserWarning)
-            return read_sbml_model(self._model)
+        return self._sbml_model
 
     @pytest.fixture(scope="function")
     def model(self, read_only_model):
         """Provide a pristine model for a test unit."""
         return read_only_model.copy()
+
+    def pytest_namespace(self):
+        """Inject global static values into the pytest namespace."""
+        blob = dict()
+        blob["biomass_reactions"] = find_biomass_reaction(self._sbml_model)
+        blob["biomass_ids"] = [rxn.id for rxn in blob["biomass_reactions"]]
+        return blob
 
     @pytest.fixture(scope="module")
     def store(self, request):

--- a/memote/suite/collect.py
+++ b/memote/suite/collect.py
@@ -28,7 +28,7 @@ try:
 except ImportError:
     import json
 import warnings
-from builtins import dict, str
+from builtins import dict
 from datetime import datetime
 
 import pytest
@@ -155,9 +155,9 @@ class ResultCollectionPlugin(object):
         self._meta["platform"] = platform.system()
         self._meta["release"] = platform.release()
         self._meta["python"] = platform.python_version()
-        self._meta["packages"] = [
+        self._meta["packages"] = dict(
             (dist.project_name, dist.version) for dist in
-            pip.get_installed_distributions()]
+            pip.get_installed_distributions())
         if self.mode == "html":
             self._meta["timestamp"] = datetime.utcnow().isoformat(" ")
             return

--- a/memote/suite/collect.py
+++ b/memote/suite/collect.py
@@ -20,7 +20,7 @@
 from __future__ import absolute_import
 
 import io
-import sys
+import platform
 import logging
 
 try:
@@ -152,10 +152,11 @@ class ResultCollectionPlugin(object):
         """Record environment information of the pytest session."""
         if self.mode == "basic":
             return
-        self._meta["platform"] = sys.platform
-        self._meta["python_version"] = sys.version
-        self._meta["python_environment"] = [
-            str(dist.as_requirement()) for dist in
+        self._meta["platform"] = platform.system()
+        self._meta["release"] = platform.release()
+        self._meta["python"] = platform.python_version()
+        self._meta["packages"] = [
+            (dist.project_name, dist.version) for dist in
             pip.get_installed_distributions()]
         if self.mode == "html":
             self._meta["timestamp"] = datetime.utcnow().isoformat(" ")

--- a/memote/suite/tests/test_biomass.py
+++ b/memote/suite/tests/test_biomass.py
@@ -25,9 +25,14 @@ to remain the same as the parametrized test cases.
 
 from __future__ import absolute_import
 
+import warnings
+
 import pytest
 import numpy as np
-from cobra.exceptions import Infeasible
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", UserWarning)
+    # ignore Gurobi warning
+    from cobra.exceptions import Infeasible
 
 import memote.support.biomass as biomass
 from memote.support.helpers import find_biomass_reaction
@@ -55,13 +60,13 @@ def test_biomass_presence(biomass_ids, store):
 
 @pytest.mark.parametrize("reaction", biomass_reactions, ids=biomass_ids)
 def test_biomass_consistency(reaction, store):
-    """Expect biomass components to sum up to 1 g / mmol / h."""
+    """Expect biomass components to sum up to 1 mmol / g[CDW] / h."""
     store["biomass_sum"] = store.get("biomass_sum", list())
     component_sum = biomass.sum_biomass_weight(reaction)
     store["biomass_sum"].append(component_sum)
     assert np.isclose(component_sum, 1.0, atol=1e-03), \
-        "{}'s components sum up to {} which is too far from 1 mmol / g / h"\
-        "".format(reaction.id, component_sum)
+        "{}'s components sum up to {} which is too far from " \
+        "1 mmol / g[CDW] / h".format(reaction.id, component_sum)
 
 
 @pytest.mark.parametrize("reaction", biomass_reactions, ids=biomass_ids)


### PR DESCRIPTION
The parametrized `test_biomass` functions were broken because fixtures cannot be used directly inside of the `pytest.mark.parametrize` decorator. Instead we now inject those values into the pytest namespace such that they are available as globals. A bit ugly but seems most feasible.