### PR TITLE
Reverse boundary check

### DIFF
--- a/memote/suite/tests/test_syntax.py
+++ b/memote/suite/tests/test_syntax.py
@@ -100,6 +100,15 @@ def test_demand_reaction_tag_match(read_only_model, store):
         " {}".format(", ".join(store["untagged_demand"]))
 
 
+def test_false_demand_reaction(read_only_model, store):
+    """Expect all rxns that are tagged with 'DM_' to be true demand rxns"""
+    store["false_demand"] = [
+        rxn.id for rxn in syntax.find_false_demand_rxns(read_only_model)]
+    assert len(store["false_demand"]) == 0, \
+        "The IDs of the following reactions are falsely tagged with 'DM_'" \
+        " {}".format(", ".join(store["false_demand"]))
+
+
 def test_sink_reaction_tag_match(read_only_model, store):
     """Expect all sink reaction IDs to be prefixed with 'SK_'."""
     store["untagged_demand"] = [
@@ -109,6 +118,15 @@ def test_sink_reaction_tag_match(read_only_model, store):
         " {}".format(", ".join(store["untagged_demand"]))
 
 
+def test_false_sink_reaction(read_only_model, store):
+    """Expect all rxns that are tagged with 'SK_' to be true sink rxns"""
+    store["false_sink"] = [
+        rxn.id for rxn in syntax.find_false_sink_rxns(read_only_model)]
+    assert len(store["false_sink"]) == 0, \
+        "The IDs of the following reactions are falsely tagged with 'SK_'" \
+        " {}".format(", ".join(store["false_sink"]))
+
+
 def test_exchange_reaction_tag_match(read_only_model, store):
     """Expect all exchange reaction IDs to be prefixed with 'EX_'."""
     store["untagged_exchange"] = [
@@ -116,3 +134,12 @@ def test_exchange_reaction_tag_match(read_only_model, store):
     assert len(store["untagged_exchange"]) == 0, \
         "The IDs of the following demand reactions are not tagged with 'EX_'" \
         " {}".format(", ".join(store["untagged_exchange"]))
+
+
+def test_false_exchange_reaction(read_only_model, store):
+    """Expect all rxns that are tagged with 'EX_' to be true exchange rxns"""
+    store["false_exchange"] = [
+        rxn.id for rxn in syntax.find_false_exchange_rxns(read_only_model)]
+    assert len(store["false_exchange"]) == 0, \
+        "The IDs of the following reactions are falsely tagged with 'EX_'" \
+        " {}".format(", ".join(store["false_exchange"]))

--- a/memote/suite/tests/test_syntax.py
+++ b/memote/suite/tests/test_syntax.py
@@ -101,7 +101,7 @@ def test_demand_reaction_tag_match(read_only_model, store):
 
 
 def test_false_demand_reaction(read_only_model, store):
-    """Expect all rxns that are tagged with 'DM_' to be true demand rxns"""
+    """Expect all rxns that are tagged with 'DM_' to be true demand rxns."""
     store["false_demand"] = [
         rxn.id for rxn in syntax.find_false_demand_rxns(read_only_model)]
     assert len(store["false_demand"]) == 0, \
@@ -119,7 +119,7 @@ def test_sink_reaction_tag_match(read_only_model, store):
 
 
 def test_false_sink_reaction(read_only_model, store):
-    """Expect all rxns that are tagged with 'SK_' to be true sink rxns"""
+    """Expect all rxns that are tagged with 'SK_' to be true sink rxns."""
     store["false_sink"] = [
         rxn.id for rxn in syntax.find_false_sink_rxns(read_only_model)]
     assert len(store["false_sink"]) == 0, \
@@ -137,7 +137,7 @@ def test_exchange_reaction_tag_match(read_only_model, store):
 
 
 def test_false_exchange_reaction(read_only_model, store):
-    """Expect all rxns that are tagged with 'EX_' to be true exchange rxns"""
+    """Expect all rxns that are tagged with 'EX_' to be true exchange rxns."""
     store["false_exchange"] = [
         rxn.id for rxn in syntax.find_false_exchange_rxns(read_only_model)]
     assert len(store["false_exchange"]) == 0, \

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -110,3 +110,104 @@ def df2dict(df):
     blob = dict((key, df[key].tolist()) for key in df.columns)
     blob["index"] = df.index.tolist()
     return blob
+
+
+def find_demand_reactions(model):
+    """
+    Return a list of demand reactions.
+
+    [1] defines demand reactions as:
+    -- 'unbalanced network reactions that allow the accumulation of a compound'
+    -- reactions that are chiefly added during the gap-filling process
+    -- as a means of dealing with 'compounds that are known to be produced by
+    the organism [..] (i) for which no information is available about their
+    fractional distribution to the biomass or (ii) which may only be produced
+    in some environmental conditions
+    -- reactions with a formula such as: 'met_c -> '
+
+    Demand reactions differ from exchange reactions in that the metabolites
+    are not removed from the extracellular environment, but from any of the
+    organism's compartments.
+
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    References
+    ----------
+    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
+    a high-quality genome-scale metabolic reconstruction. Nature protocols.
+    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+
+    """
+    demand_and_exchange_rxns = set(model.exchanges)
+    return [rxn for rxn in demand_and_exchange_rxns
+            if not rxn.reversibility and
+            rxn.get_compartments() not in ['e']]
+
+
+def find_sink_reactions(model):
+    """
+    Return a list of sink reactions.
+
+    [1] defines sink reactions as:
+    -- 'similar to demand reactions' but reversible, thus able to supply the
+    model with metabolites
+    -- reactions that are chiefly added during the gap-filling process
+    -- as a means of dealing with 'compounds that are produced by nonmetabolic
+    cellular processes but that need to be metabolized'
+    -- reactions with a formula such as: 'met_c <-> '
+
+    Sink reactions differ from exchange reactions in that the metabolites
+    are not removed from the extracellular environment, but from any of the
+    organism's compartments.
+
+    Parameters
+    ----------
+    model : cobra.Model
+             A cobrapy metabolic model
+
+    References
+    ----------
+    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
+    a high-quality genome-scale metabolic reconstruction. Nature protocols.
+    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+
+    """
+    demand_and_exchange_rxns = set(model.exchanges)
+    return [rxn for rxn in demand_and_exchange_rxns
+            if rxn.reversibility and
+            rxn.get_compartments() not in ['e']]
+
+
+def find_exchange_rxns(model):
+    """
+    Return a list of exchange reactions.
+
+    [1] defines exchange reactions as:
+    -- reactions that 'define the extracellular environment'
+    -- 'unbalanced, extra-organism reactions that represent the supply to or
+    removal of metabolites from the extra-organism "space"'
+    -- reactions with a formula such as: 'met_e -> ' or ' -> met_e' or
+    'met_e <=> '
+
+    Exchange reactions differ from demand reactions in that the metabolites
+    are removed from or added to the extracellular environment only. With this
+    the uptake or secretion of a metabolite is modeled, respectively.
+
+    Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    References
+    ----------
+    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
+    a high-quality genome-scale metabolic reconstruction. Nature protocols.
+    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
+
+    """
+    demand_and_exchange_rxns = set(model.exchanges)
+    return [rxn for rxn in demand_and_exchange_rxns
+            if rxn.get_compartments() == ['e']]

--- a/memote/support/helpers.py
+++ b/memote/support/helpers.py
@@ -143,8 +143,8 @@ def find_demand_reactions(model):
     """
     demand_and_exchange_rxns = set(model.exchanges)
     return [rxn for rxn in demand_and_exchange_rxns
-            if not rxn.reversibility and
-            rxn.get_compartments() not in ['e']]
+            if not rxn.reversibility and not
+            any(c in rxn.get_compartments() for c in ['e'])]
 
 
 def find_sink_reactions(model):
@@ -177,8 +177,8 @@ def find_sink_reactions(model):
     """
     demand_and_exchange_rxns = set(model.exchanges)
     return [rxn for rxn in demand_and_exchange_rxns
-            if rxn.reversibility and
-            rxn.get_compartments() not in ['e']]
+            if rxn.reversibility and not
+            any(c in rxn.get_compartments() for c in ['e'])]
 
 
 def find_exchange_rxns(model):
@@ -210,4 +210,4 @@ def find_exchange_rxns(model):
     """
     demand_and_exchange_rxns = set(model.exchanges)
     return [rxn for rxn in demand_and_exchange_rxns
-            if rxn.get_compartments() == ['e']]
+            if any(c in rxn.get_compartments() for c in ['e'])]

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -217,6 +217,24 @@ def find_untagged_demand_rxns(model):
             if not re.match(comp_pattern, rxn.id)]
 
 
+def find_false_demand_rxns(model):
+    """
+    Find reactions which are tagged with 'DM_' but which are not demand rxns.
+
+        Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    """
+    true_demand_rxns = helpers.find_demand_reactions(model)
+    comp_pattern = "^DM_\w*?"
+    all_rxns_tagged_DM = [rxn for rxn in model.reactions
+            if re.match(comp_pattern, rxn.id)]
+    #false demand reactions
+    return set(all_rxns_tagged_DM).difference(set(true_demand_rxns))
+
+
 def find_untagged_sink_rxns(model):
     """
     Find demand reactions whose IDs do not begin with 'SK_'.
@@ -233,6 +251,24 @@ def find_untagged_sink_rxns(model):
             if not re.match(comp_pattern, rxn.id)]
 
 
+def find_false_sink_rxns(model):
+    """
+    Find reactions which are tagged with 'SK_' but which are not sink rxns.
+
+        Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    """
+    true_sink_rxns = helpers.find_sink_reactions(model)
+    comp_pattern = "^SK_\w*?"
+    all_rxns_tagged_SK = [rxn for rxn in model.reactions
+            if re.match(comp_pattern, rxn.id)]
+    #false sink reactions
+    return set(all_rxns_tagged_SK).difference(set(true_sink_rxns))
+
+
 def find_untagged_exchange_rxns(model):
     """
     Find exchange reactions whose IDs do not begin with 'EX_'.
@@ -247,3 +283,21 @@ def find_untagged_exchange_rxns(model):
     comp_pattern = "^EX_\w*?"
     return [rxn for rxn in exchange_rxns
             if not re.match(comp_pattern, rxn.id)]
+
+
+def find_false_exchange_rxns(model):
+    """
+    Find reactions which are tagged with 'EX_' but which are not exchange rxns.
+
+        Parameters
+    ----------
+    model : cobra.Model
+            A cobrapy metabolic model
+
+    """
+    true_exchange_rxns = helpers.find_exchange_reactions(model)
+    comp_pattern = "^SK_\w*?"
+    all_rxns_tagged_EX = [rxn for rxn in model.reactions
+            if re.match(comp_pattern, rxn.id)]
+    #false exchange reactions
+    return set(all_rxns_tagged_EX).difference(set(true_exchange_rxns))

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -230,8 +230,8 @@ def find_false_demand_rxns(model):
     true_demand_rxns = helpers.find_demand_reactions(model)
     comp_pattern = "^DM_\w*?"
     all_rxns_tagged_DM = [rxn for rxn in model.reactions
-            if re.match(comp_pattern, rxn.id)]
-    #false demand reactions
+                          if re.match(comp_pattern, rxn.id)]
+    # false demand reactions
     return set(all_rxns_tagged_DM).difference(set(true_demand_rxns))
 
 
@@ -264,8 +264,8 @@ def find_false_sink_rxns(model):
     true_sink_rxns = helpers.find_sink_reactions(model)
     comp_pattern = "^SK_\w*?"
     all_rxns_tagged_SK = [rxn for rxn in model.reactions
-            if re.match(comp_pattern, rxn.id)]
-    #false sink reactions
+                          if re.match(comp_pattern, rxn.id)]
+    # false sink reactions
     return set(all_rxns_tagged_SK).difference(set(true_sink_rxns))
 
 
@@ -298,6 +298,6 @@ def find_false_exchange_rxns(model):
     true_exchange_rxns = helpers.find_exchange_rxns(model)
     comp_pattern = "^EX_\w*?"
     all_rxns_tagged_EX = [rxn for rxn in model.reactions
-            if re.match(comp_pattern, rxn.id)]
-    #false exchange reactions
+                          if re.match(comp_pattern, rxn.id)]
+    # false exchange reactions
     return set(all_rxns_tagged_EX).difference(set(true_exchange_rxns))

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -295,7 +295,7 @@ def find_false_exchange_rxns(model):
             A cobrapy metabolic model
 
     """
-    true_exchange_rxns = helpers.find_exchange_reactions(model)
+    true_exchange_rxns = helpers.find_exchange_rxns(model)
     comp_pattern = "^EX_\w*?"
     all_rxns_tagged_EX = [rxn for rxn in model.reactions
             if re.match(comp_pattern, rxn.id)]

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -42,7 +42,7 @@ SUFFIX_MAP = dict({
 
 def find_rxn_id_compartment_suffix(model, suffix):
     """
-    Find incorrectly tagged IDs.
+    Find un-tagged non-transport reactions.
 
     Find non-transport reactions with metabolites in the given compartment
     whose ID is not tagged accordingly.
@@ -82,7 +82,7 @@ def find_rxn_id_compartment_suffix(model, suffix):
 
 def find_rxn_id_suffix_compartment(model, suffix):
     """
-    Find incorrectly tagged non-transport reactions.
+    Find mis-tagged non-transport reactions.
 
     Find non-transport reactions whose ID bear a compartment tag but which do
     not contain any metabolites in the given compartment.

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -296,7 +296,7 @@ def find_false_exchange_rxns(model):
 
     """
     true_exchange_rxns = helpers.find_exchange_reactions(model)
-    comp_pattern = "^SK_\w*?"
+    comp_pattern = "^EX_\w*?"
     all_rxns_tagged_EX = [rxn for rxn in model.reactions
             if re.match(comp_pattern, rxn.id)]
     #false exchange reactions

--- a/memote/support/syntax.py
+++ b/memote/support/syntax.py
@@ -23,8 +23,7 @@ import logging
 import re
 from builtins import dict
 
-from memote.support.helpers import (
-    find_atp_adp_converting_reactions, find_transport_reactions)
+import memote.support.helpers as helpers
 
 LOGGER = logging.getLogger(__name__)
 
@@ -63,7 +62,7 @@ def find_rxn_id_compartment_suffix(model, suffix):
         the `suffix` appended.
 
     """
-    transport_rxns = set(find_transport_reactions(model))
+    transport_rxns = set(helpers.find_transport_reactions(model))
     exchange_demand_rxns = set(model.exchanges)
 
     comp_pattern = re.compile(
@@ -103,7 +102,7 @@ def find_rxn_id_suffix_compartment(model, suffix):
         the `suffix` appended.
 
     """
-    transport_rxns = set(find_transport_reactions(model))
+    transport_rxns = set(helpers.find_transport_reactions(model))
     exchange_demand_rxns = set(model.exchanges)
 
     comp_pattern = re.compile(
@@ -141,8 +140,8 @@ def find_reaction_tag_transporter(model):
             A cobrapy metabolic model
 
     """
-    transport_rxns = find_transport_reactions(model)
-    atp_adp_rxns = find_atp_adp_converting_reactions(model)
+    transport_rxns = helpers.find_transport_reactions(model)
+    atp_adp_rxns = helpers.find_atp_adp_converting_reactions(model)
 
     non_abc_transporters = set(transport_rxns).difference(set(atp_adp_rxns))
 
@@ -171,8 +170,8 @@ def find_abc_tag_transporter(model):
             A cobrapy metabolic model
 
     """
-    transport_rxns = find_transport_reactions(model)
-    atp_adp_rxns = find_atp_adp_converting_reactions(model)
+    transport_rxns = helpers.find_transport_reactions(model)
+    atp_adp_rxns = helpers.find_atp_adp_converting_reactions(model)
 
     abc_transporters = set(transport_rxns).intersection(set(atp_adp_rxns))
 
@@ -206,36 +205,13 @@ def find_untagged_demand_rxns(model):
     """
     Find demand reactions whose IDs do not begin with 'DM_'.
 
-    [1] defines demand reactions as:
-    -- 'unbalanced network reactions that allow the accumulation of a compound'
-    -- reactions that are chiefly added during the gap-filling process
-    -- as a means of dealing with 'compounds that are known to be produced by
-    the organism [..] (i) for which no information is available about their
-    fractional distribution to the biomass or (ii) which may only be produced
-    in some environmental conditions
-    -- reactions with a formula such as: 'met_c -> '
-
-    Demand reactions differ from exchange reactions in that the metabolites
-    are not removed from the extracellular environment, but from any of the
-    organism's compartments.
-
-    Parameters
+        Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
 
-    References
-    ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
-
     """
-    demand_and_exchange_rxns = set(model.exchanges)
-    demand_rxns = [rxn for rxn in demand_and_exchange_rxns
-                   if not rxn.reversibility and
-                   rxn.get_compartments() not in ['e']]
-
+    demand_rxns = helpers.find_demand_reactions(model)
     comp_pattern = "^DM_\w*?"
     return [rxn for rxn in demand_rxns
             if not re.match(comp_pattern, rxn.id)]
@@ -245,35 +221,13 @@ def find_untagged_sink_rxns(model):
     """
     Find demand reactions whose IDs do not begin with 'SK_'.
 
-    [1] defines sink reactions as:
-    -- 'similar to demand reactions' but reversible, thus able to supply the
-    model with metabolites
-    -- reactions that are chiefly added during the gap-filling process
-    -- as a means of dealing with 'compounds that are produced by nonmetabolic
-    cellular processes but that need to be metabolized'
-    -- reactions with a formula such as: 'met_c <-> '
-
-    Sink reactions differ from exchange reactions in that the metabolites
-    are not removed from the extracellular environment, but from any of the
-    organism's compartments.
-
     Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
 
-    References
-    ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
-
     """
-    demand_and_exchange_rxns = set(model.exchanges)
-    sink_rxns = [rxn for rxn in demand_and_exchange_rxns
-                 if rxn.reversibility and
-                 rxn.get_compartments() not in ['e']]
-
+    sink_rxns = helpers.find_sink_reactions(model)
     comp_pattern = "^SK_\w*?"
     return [rxn for rxn in sink_rxns
             if not re.match(comp_pattern, rxn.id)]
@@ -283,33 +237,13 @@ def find_untagged_exchange_rxns(model):
     """
     Find exchange reactions whose IDs do not begin with 'EX_'.
 
-    [1] defines exchange reactions as:
-    -- reactions that 'define the extracellular environment'
-    -- 'unbalanced, extra-organism reactions that represent the supply to or
-    removal of metabolites from the extra-organism "space"'
-    -- reactions with a formula such as: 'met_e -> ' or ' -> met_e' or
-    'met_e <=> '
-
-    Exchange reactions differ from demand reactions in that the metabolites
-    are removed from or added to the extracellular environment only. With this
-    the uptake or secretion of a metabolite is modeled, respectively.
-
     Parameters
     ----------
     model : cobra.Model
             A cobrapy metabolic model
 
-    References
-    ----------
-    [1] Thiele, I., & Palsson, B. Ø. (2010, January). A protocol for generating
-    a high-quality genome-scale metabolic reconstruction. Nature protocols.
-    Nature Publishing Group. http://doi.org/10.1038/nprot.2009.203
-
     """
-    demand_and_exchange_rxns = set(model.exchanges)
-    exchange_rxns = [rxn for rxn in demand_and_exchange_rxns
-                     if rxn.get_compartments() == ['e']]
-
+    exchange_rxns = helpers.find_exchange_rxns(model)
     comp_pattern = "^EX_\w*?"
     return [rxn for rxn in exchange_rxns
             if not re.match(comp_pattern, rxn.id)]

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -370,7 +370,7 @@ def model_builder(name):
     ("rxn_no_tags", 1)
 ], indirect=["model"])
 def test_non_transp_rxn_id_compartment_suffix_match(model, num):
-    """Expect all rxns outside of the cytosol to be tagged accordingly"""
+    """Expect all rxns outside of the cytosol to be tagged accordingly."""
     for compartment in model.compartments:
         if compartment != 'c':
             rxn_lst = syntax.find_rxn_id_compartment_suffix(model, compartment)
@@ -384,7 +384,7 @@ def test_non_transp_rxn_id_compartment_suffix_match(model, num):
 def test_non_transp_rxn_id_suffix_compartment_match(model, num):
     """
     Expect all rxns that are tagged to be in a compartment to at least
-    partially involve mets from that compartment
+    partially involve mets from that compartment.
     """
     for compartment in model.compartments:
         if compartment != 'c':
@@ -402,7 +402,7 @@ def test_non_transp_rxn_id_suffix_compartment_match(model, num):
     ("proton_pump", 0)
 ], indirect=["model"])
 def test_non_abc_transp_rxn_tag_match(model, num):
-    """Expect all non-abc transport rxns to be tagged with a 't'"""
+    """Expect all non-abc transport rxns to be tagged with a 't'."""
     trxn_lst = syntax.find_reaction_tag_transporter(model)
     assert len(trxn_lst) == num
 
@@ -412,7 +412,7 @@ def test_non_abc_transp_rxn_tag_match(model, num):
     ("trxn_no_tag_atp_driven", 1)
 ], indirect=["model"])
 def test_abc_transp_rxn_tag_match(model, num):
-    """Expect all abc transport rxns to be tagged with 'abc'"""
+    """Expect all abc transport rxns to be tagged with 'abc'."""
     untagged_atp_transport_rxns = syntax.find_abc_tag_transporter(model)
     assert len(untagged_atp_transport_rxns) == num
 
@@ -422,7 +422,7 @@ def test_abc_transp_rxn_tag_match(model, num):
     ("upper_case_mets", 5)
 ], indirect=["model"])
 def test_upper_case_mets(model, num):
-    """Expect all metabolites to be lower case within accepted exceptions"""
+    """Expect all metabolites to be lower case within accepted exceptions."""
     upper_case_mets = syntax.find_upper_case_mets(model)
     assert len(upper_case_mets) == num
 
@@ -432,7 +432,7 @@ def test_upper_case_mets(model, num):
     ("missing_demand_tag", 2)
 ], indirect=["model"])
 def test_demand_reaction_tag_match(model, num):
-    """Expect all demand rxn IDs to be prefixed with 'DM_'"""
+    """Expect all demand rxn IDs to be prefixed with 'DM_'."""
     untagged_tagged_demand_rxns = syntax.find_untagged_demand_rxns(model)
     assert len(untagged_tagged_demand_rxns) == num
 
@@ -443,7 +443,7 @@ def test_demand_reaction_tag_match(model, num):
     ("missing_exchange_tag", 1)
 ], indirect=["model"])
 def test_false_demand_reaction(model, num):
-    """Expect all rxns that are tagged with 'DM_' to be true demand rxns"""
+    """Expect all rxns that are tagged with 'DM_' to be true demand rxns."""
     falsely_tagged_demand_rxns = syntax.find_false_demand_rxns(model)
     assert len(falsely_tagged_demand_rxns) == num
 
@@ -453,7 +453,7 @@ def test_false_demand_reaction(model, num):
     ("missing_sink_tag", 2)
 ], indirect=["model"])
 def test_sink_reaction_tag_match(model, num):
-    """Expect all sink rxn IDs to be prefixed with 'SK_'"""
+    """Expect all sink rxn IDs to be prefixed with 'SK_'."""
     untagged_tagged_sink_rxns = syntax.find_untagged_sink_rxns(model)
     assert len(untagged_tagged_sink_rxns) == num
 
@@ -463,7 +463,7 @@ def test_sink_reaction_tag_match(model, num):
     ("false_sink_tag", 1)
 ], indirect=["model"])
 def test_false_sink_reaction(model, num):
-    """Expect all rxns that are tagged with 'SK_' to be true sink rxns"""
+    """Expect all rxns that are tagged with 'SK_' to be true sink rxns."""
     falsely_tagged_sink_rxns = syntax.find_false_sink_rxns(model)
     assert len(falsely_tagged_sink_rxns) == num
 
@@ -473,7 +473,7 @@ def test_false_sink_reaction(model, num):
     ("missing_exchange_tag", 2)
 ], indirect=["model"])
 def test_exchange_reaction_tag_match(model, num):
-    """Expect all exchange rxn IDs to be prefixed with 'EX_'"""
+    """Expect all exchange rxn IDs to be prefixed with 'EX_'."""
     untagged_tagged_exchange_rxns = syntax.find_untagged_exchange_rxns(model)
     assert len(untagged_tagged_exchange_rxns) == num
 
@@ -483,6 +483,6 @@ def test_exchange_reaction_tag_match(model, num):
     ("missing_demand_tag", 1)
 ], indirect=["model"])
 def test_false_exchange_reaction(model, num):
-    """Expect all rxns that are tagged with 'EX_' to be true exchange rxns"""
+    """Expect all rxns that are tagged with 'EX_' to be true exchange rxns."""
     falsely_tagged_exchange_rxns = syntax.find_false_exchange_rxns(model)
     assert len(falsely_tagged_exchange_rxns) == num

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -252,7 +252,7 @@ def correct_demand_tag(base):
     return base
 
 
-def incorrect_demand_tag(base):
+def missing_demand_tag(base):
     rxn = cobra.Reaction('EX_abc_c')
     rxn.add_metabolites(
         {cobra.Metabolite(id="abc_c",
@@ -267,6 +267,16 @@ def incorrect_demand_tag(base):
     return base
 
 
+def false_demand_tag(base):
+    rxn = cobra.Reaction('DM_abc_c')
+    rxn.add_metabolites(
+        {cobra.Metabolite(id="abc_e",
+                          compartment='e'): -1}
+    )
+    base.add_reaction(rxn)
+    return base
+
+
 def correct_exchange_tag(base):
     rxn = cobra.Reaction('EX_abc_e')
     rxn.add_metabolites(
@@ -277,7 +287,7 @@ def correct_exchange_tag(base):
     return base
 
 
-def incorrect_exchange_tag(base):
+def missing_exchange_tag(base):
     rxn = cobra.Reaction('DM_ghi_e')
     rxn.add_metabolites(
         {cobra.Metabolite(id="ghi_e",
@@ -303,7 +313,7 @@ def correct_sink_tag(base):
     return base
 
 
-def incorrect_sink_tag(base):
+def missing_sink_tag(base):
     rxn = cobra.Reaction('EX_abc_c')
     rxn.add_metabolites(
         {cobra.Metabolite(id="abc_c",
@@ -332,11 +342,11 @@ def model_builder(name):
         "lower_case_mets": lower_case_mets,
         "upper_case_mets": upper_case_mets,
         "correct_demand_tag": correct_demand_tag,
-        "incorrect_demand_tag": incorrect_demand_tag,
+        "missing_demand_tag": missing_demand_tag,
         "correct_exchange_tag": correct_exchange_tag,
-        "incorrect_exchange_tag": incorrect_exchange_tag,
+        "missing_exchange_tag": missing_exchange_tag,
         "correct_sink_tag": correct_sink_tag,
-        "incorrect_sink_tag": incorrect_sink_tag,
+        "missing_sink_tag": missing_sink_tag,
     }
     model = cobra.Model(id_or_model=name, name=name)
     return choices[name](model)
@@ -406,29 +416,39 @@ def test_upper_case_mets(model, num):
 
 @pytest.mark.parametrize("model, num", [
     ("correct_demand_tag", 0),
-    ("incorrect_demand_tag", 2)
+    ("missing_demand_tag", 2)
 ], indirect=["model"])
 def test_demand_reaction_tag_match(model, num):
     """Expect all demand rxn IDs to be prefixed with 'DM_'"""
-    falsely_tagged_demand_rxns = syntax.find_untagged_demand_rxns(model)
+    untagged_tagged_demand_rxns = syntax.find_untagged_demand_rxns(model)
+    assert len(untagged_tagged_demand_rxns) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("correct_demand_tag", 0),
+    ("false_demand_tag", 1)
+], indirect=["model"])
+def test_false_demand_reaction(model, num):
+    """Expect all no rxn to be tagged DM that is not a demand reaction"""
+    falsely_tagged_demand_rxns = syntax.find_false_demand_rxns(model)
     assert len(falsely_tagged_demand_rxns) == num
 
 
 @pytest.mark.parametrize("model, num", [
     ("correct_sink_tag", 0),
-    ("incorrect_sink_tag", 2)
+    ("missing_sink_tag", 2)
 ], indirect=["model"])
 def test_sink_reaction_tag_match(model, num):
     """Expect all sink rxn IDs to be prefixed with 'SK_'"""
-    falsely_tagged_sink_rxns = syntax.find_untagged_sink_rxns(model)
-    assert len(falsely_tagged_sink_rxns) == num
+    untagged_tagged_sink_rxns = syntax.find_untagged_sink_rxns(model)
+    assert len(untagged_tagged_sink_rxns) == num
 
 
 @pytest.mark.parametrize("model, num", [
     ("correct_exchange_tag", 0),
-    ("incorrect_exchange_tag", 2)
+    ("missing_exchange_tag", 2)
 ], indirect=["model"])
 def test_exchange_reaction_tag_match(model, num):
     """Expect all exchange rxn IDs to be prefixed with 'EX_'"""
-    falsely_tagged_exchange_rxns = syntax.find_untagged_exchange_rxns(model)
-    assert len(falsely_tagged_exchange_rxns) == num
+    untagged_tagged_exchange_rxns = syntax.find_untagged_exchange_rxns(model)
+    assert len(untagged_tagged_exchange_rxns) == num

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -343,6 +343,7 @@ def model_builder(name):
         "upper_case_mets": upper_case_mets,
         "correct_demand_tag": correct_demand_tag,
         "missing_demand_tag": missing_demand_tag,
+        "false_demand_tag": false_demand_tag,
         "correct_exchange_tag": correct_exchange_tag,
         "missing_exchange_tag": missing_exchange_tag,
         "correct_sink_tag": correct_sink_tag,

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -268,7 +268,7 @@ def missing_demand_tag(base):
 
 
 def false_demand_tag(base):
-    rxn = cobra.Reaction('DM_abc_c')
+    rxn = cobra.Reaction('DM_abc_e')
     rxn.add_metabolites(
         {cobra.Metabolite(id="abc_e",
                           compartment='e'): -1}

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -430,7 +430,7 @@ def test_demand_reaction_tag_match(model, num):
     ("false_demand_tag", 1)
 ], indirect=["model"])
 def test_false_demand_reaction(model, num):
-    """Expect all no rxn to be tagged DM that is not a demand reaction"""
+    """Expect all rxns that are tagged with 'DM_' to be true demand rxns"""
     falsely_tagged_demand_rxns = syntax.find_false_demand_rxns(model)
     assert len(falsely_tagged_demand_rxns) == num
 

--- a/tests/test_for_support/test_for_syntax.py
+++ b/tests/test_for_support/test_for_syntax.py
@@ -460,7 +460,7 @@ def test_sink_reaction_tag_match(model, num):
 
 @pytest.mark.parametrize("model, num", [
     ("correct_sink_tag", 0),
-    ("false_sink_tag", 2)
+    ("false_sink_tag", 1)
 ], indirect=["model"])
 def test_false_sink_reaction(model, num):
     """Expect all rxns that are tagged with 'SK_' to be true sink rxns"""


### PR DESCRIPTION
resolves #116

Straight forward fix again. Concerns the modules syntax, test_for_syntax and test_syntax. Adds the reverse case of #102 checking that DM, SK, and EX-labeled reactions are indeed demand, sink and exchange reactions.