### PR TITLE
Type III loops or Stoichiometrically Balanced Cycles

### DIFF
--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -64,7 +64,7 @@ def test_blocked_reactions(read_only_model, store):
             ", ".join(store["blocked_reactions"]))
 
 
-def test_find_stoichiometrically_balanced_cycles(read_only_model, num):
+def test_find_stoichiometrically_balanced_cycles(read_only_model, num, store):
     """Expect no stoichiometrically balanced loops to be present."""
     store["looped_reactions"] = [
         rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(

--- a/memote/suite/tests/test_consistency.py
+++ b/memote/suite/tests/test_consistency.py
@@ -62,3 +62,15 @@ def test_blocked_reactions(read_only_model, store):
     assert len(store["blocked_reactions"]) == 0,\
         "The following reactions are blocked: {}".format(
             ", ".join(store["blocked_reactions"]))
+
+
+def test_find_stoichiometrically_balanced_cycles(read_only_model, num):
+    """Expect no stoichiometrically balanced loops to be present."""
+    store["looped_reactions"] = [
+        rxn.id for rxn in consistency.find_stoichiometrically_balanced_cycles(
+            read_only_model
+        )]
+    assert len(store["looped_reactions"]) == 0,\
+        "The following reactions participate in stoichiometrically balanced" \
+        " cycles: {}".format(
+            ", ".join(store["looped_reactions"]))

--- a/tests/test_for_support/test_for_consistency.py
+++ b/tests/test_for_support/test_for_consistency.py
@@ -149,6 +149,42 @@ def charge_imbalanced(base):
     return base
 
 
+def loopy_toy_model(base):
+    base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
+    base.add_reactions([cobra.Reaction(i)
+                        for i in ["VA", "VB", "v1", "v2", "v3"]]
+                       )
+    base.reactions.VA.add_metabolites({"A": 1})
+    base.reactions.VB.add_metabolites({"C": -1})
+    base.reactions.v1.add_metabolites({"A": -1, "B": 1})
+    base.reactions.v2.add_metabolites({"B": -1, "C": 1})
+    base.reactions.v3.add_metabolites({"A": -1, "C": 1})
+    base.reactions.v1.bounds = -1000, 1000
+    base.reactions.v2.bounds = -1000, 1000
+    base.reactions.v3.bounds = -1000, 1000
+    base.objective = 'VB'
+    base.reactions.VB.bounds = 0, 1
+    return base
+
+
+def constrained_toy_model(base):
+    base.add_metabolites([cobra.Metabolite(i) for i in "ABC"])
+    base.add_reactions([cobra.Reaction(i)
+                        for i in ["VA", "VB", "v1", "v2", "v3"]]
+                       )
+    base.reactions.VA.add_metabolites({"A": 1})
+    base.reactions.VB.add_metabolites({"C": -1})
+    base.reactions.v1.add_metabolites({"A": -1, "B": 1})
+    base.reactions.v2.add_metabolites({"B": -1, "C": 1})
+    base.reactions.v3.add_metabolites({"A": -1, "C": 1})
+    base.reactions.v1.bounds = -1000, 1000
+    base.reactions.v2.bounds = -1000, 1000
+    base.reactions.v3.bounds = 1, 1
+    base.objective = 'VB'
+    base.reactions.VB.bounds = 0, 1
+    return base
+
+
 def model_builder(name):
     choices = {
         "fig-1": figure_1,
@@ -159,6 +195,8 @@ def model_builder(name):
         "all_balanced": all_balanced,
         "mass_imbalanced": mass_imbalanced,
         "charge_imbalanced": charge_imbalanced,
+        "loopy_toy_model": loopy_toy_model,
+        "constrained_toy_model": constrained_toy_model,
     }
     model = cobra.Model(id_or_model=name, name=name)
     return choices[name](model)
@@ -226,3 +264,13 @@ def test_blocked_reactions(model, num):
     """Expect all reactions to be able to carry flux."""
     dict_of_blocked_rxns = consistency.find_blocked_reactions(model)
     assert len(dict_of_blocked_rxns) == num
+
+
+@pytest.mark.parametrize("model, num", [
+    ("loopy_toy_model", 3),
+    ("constrained_toy_model", 0),
+], indirect=["model"])
+def test_find_stoichiometrically_balanced_cycles(model, num):
+    """Expect no stoichiometrically balanced loops to be present."""
+    rxns_in_loops = consistency.find_stoichiometrically_balanced_cycles(model)
+    assert len(rxns_in_loops) == num


### PR DESCRIPTION
resolves #104 

This PR tackles the identification and testing for reactions that participate in stoichiometrically balanced cycles (SBCs) or also referred to as Type III pathways. What I implemented is nominal FVA with the default objective and default bounds, followed by loopless FVA (the fast variant using the CycleFreeFlux algorithm in cobrapy). I then list all reactions that show a different flux distribution.

My initial approach, the one described in #104 doesn't work as the FVA solution with closed bounds becomes infeasible with models that have a defined (fast constrained) NGAM requirement.

The changes only affect the models involving functions from consistency.py